### PR TITLE
Fix: error in the cornercase of connecting the database server

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -172,7 +172,7 @@ if(isset($_POST['install_submit']))
   if(empty($errors))
    {
     $connid = @mysqli_connect($_POST['host'], $_POST['user'], $_POST['password']);
-    if(!$connid) $errors[] = $lang['error_db_connection']." (MySQL: ".mysqli_error($connid).")";
+    if(!$connid) $errors[] = $lang['error_db_connection']." (MySQL: ".mysqli_connect_error().")";
    }
 
   if(empty($errors))


### PR DESCRIPTION
The script can't use the connection identifier to report it's absence. Use the correct function for this case.

It's only a corner case but a common one. It could often occure, that users speciffy incorrect informations about the database connection. And in my case it did when I specified the server name with a typing error.