### PR TITLE
Constructor for PHP7

### DIFF
--- a/modules/stringparser_bbcode/stringparser.class.php
+++ b/modules/stringparser_bbcode/stringparser.class.php
@@ -6,11 +6,12 @@
  * memory structure. It would e.g. be possible to create an HTML parser based
  * upon this class.
  * 
- * Version: 0.3.3
+ * Version: 0.3.3 - Modified by Michael Loesler: Fix PHP7 issue for __construct
  *
  * @author Christian Seiler <spam@christian-seiler.de>
  * @copyright Christian Seiler 2004-2008
  * @package stringparser
+ *
  *
  * The MIT License
  *
@@ -193,13 +194,22 @@ class StringParser {
 	 * @var bool
 	 */
 	var $_recentlyReparsed = false;
-	 
+	
+
 	/**
-	 * Constructor
+	 * Constructor for StringParser (PHP7)
+	 *
+	 * @access public
+	 */
+	function __construct() {}
+	
+	/**
+	 * Constructor for StringParser
 	 *
 	 * @access public
 	 */
 	function StringParser () {
+		self::__construct();
 	}
 	
 	/**
@@ -899,8 +909,26 @@ class StringParser_Node {
 	 */
 	var $occurredAt = -1;
 	
+	
+	
 	/**
-	 * Constructor
+	 * Constructor for StringParser_Node (PHP7)
+	 *
+	 * Currently, the constructor only allocates a new ID for the node and
+	 * assigns it.
+	 *
+	 * @access public
+	 * @param int $occurredAt The position in the text where this node
+	 *                        occurred at. If not determinable, it is -1.
+	 * @global __STRINGPARSER_NODE_ID
+	 */
+	function __construct($occurredAt = -1) {
+		$this->_id = $GLOBALS['__STRINGPARSER_NODE_ID']++;
+		$this->occurredAt = $occurredAt;
+	}
+	
+	/**
+	 * Constructor for StringParser_Node
 	 *
 	 * Currently, the constructor only allocates a new ID for the node and
 	 * assigns it.
@@ -911,8 +939,7 @@ class StringParser_Node {
 	 * @global __STRINGPARSER_NODE_ID
 	 */
 	function StringParser_Node ($occurredAt = -1) {
-		$this->_id = $GLOBALS['__STRINGPARSER_NODE_ID']++;
-		$this->occurredAt = $occurredAt;
+		self::__construct($occurredAt);
 	}
 	
 	/**
@@ -1478,7 +1505,21 @@ class StringParser_Node_Text extends StringParser_Node {
 	var $content = '';
 	
 	/**
-	 * Constructor
+	 * Constructor for StringParser_Node_Text (PHP7)
+	 *
+	 * @access public
+	 * @param string $content The initial content of this element
+	 * @param int $occurredAt The position in the text where this node
+	 *                        occurred at. If not determinable, it is -1.
+	 * @see StringParser_Node_Text::content
+	 */
+	function __construct ($content, $occurredAt = -1) {
+		parent::StringParser_Node ($occurredAt);
+		$this->content = $content;
+	}
+	
+	/**
+	 * Constructor for StringParser_Node_Text
 	 *
 	 * @access public
 	 * @param string $content The initial content of this element
@@ -1487,8 +1528,7 @@ class StringParser_Node_Text extends StringParser_Node {
 	 * @see StringParser_Node_Text::content
 	 */
 	function StringParser_Node_Text ($content, $occurredAt = -1) {
-		parent::StringParser_Node ($occurredAt);
-		$this->content = $content;
+		self::__construct ($content, $occurredAt);
 	}
 	
 	/**

--- a/modules/stringparser_bbcode/stringparser_bbcode.class.php
+++ b/modules/stringparser_bbcode/stringparser_bbcode.class.php
@@ -1449,10 +1449,12 @@ class StringParser_BBCode_Node_Paragraph extends StringParser_Node {
 			$f_begin = $this->_children[0]->getFlag ('newlinemode.begin', 'integer', BBCODE_NEWLINE_PARSE);
 			$f_end = $this->_children[0]->getFlag ('newlinemode.end', 'integer', BBCODE_NEWLINE_PARSE);
 			$content = $this->_children[0]->content;
-			if ($f_begin != BBCODE_NEWLINE_PARSE && $content{0} == "\n") {
+			// MiLo: Check for content lenght
+			if ($f_begin != BBCODE_NEWLINE_PARSE && strlen ($content) > 0 && $content{0} == "\n") {
 				$content = substr ($content, 1);
 			}
-			if ($f_end != BBCODE_NEWLINE_PARSE && $content{strlen($content)-1} == "\n") {
+			// MiLo: Check for content lenght
+			if ($f_end != BBCODE_NEWLINE_PARSE && strlen ($content) > 0 && $content{strlen($content)-1} == "\n") {
 				$content = substr ($content, 0, -1);
 			}
 			if (!strlen ($content)) {


### PR DESCRIPTION
- Add __construct-Function to classes to be valid for PHP7
- Check length of content-string @matchesCriterium-function to avoid a
PHP note