### PR TITLE
Fix: replace graphic separators with CSS-text (with :before)

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -44,8 +44,12 @@ img.show-sidebar         { background:url(images/bg_sprite_2.png) no-repeat 0 -2
 #nav                     { margin:0; padding:7px 20px 7px 0; text-align:right; }
 
 #usermenu                { margin:0 0 1em 0; font-size:0.69em; list-style-type:none; }
-#usermenu li             { display:inline; margin-left:6px; padding-left:7px; background:url(images/bg_sprite_1.png) no-repeat 0 -1097px; }
-#usermenu li:first-child { margin-left:0; padding-left:0; background:none; }
+#usermenu li             { display:inline; margin-left:5px; }
+#usermenu li:first-child { margin-left:0; padding-left:0; }
+#usermenu li:before      { content: "|"; }
+#usermenu li:first-child:before
+                         { content: ""; }
+#usermenu li a           { padding-left: 4px; }
 
 #topsearch               { display:inline; }
 #topsearch div           { display:inline; font-size:0.82em; }

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -26,8 +26,11 @@ img.show-sidebar{background:url(images/bg_sprite_2.png) no-repeat 0 -22px}
 #logo .index{margin:0;padding:0;font-size:.82em}
 #nav{margin:0;padding:7px 20px 7px 0;text-align:right}
 #usermenu{margin:0 0 1em;font-size:.69em;list-style-type:none}
-#usermenu li{display:inline;margin-left:6px;padding-left:7px;background:url(images/bg_sprite_1.png) no-repeat 0 -1097px}
-#usermenu li:first-child{margin-left:0;padding-left:0;background:none}
+#usermenu li{display:inline-block;margin-left:5px}
+#usermenu li:first-child{margin-left:0;padding-left:0}
+#usermenu li:before{content:"|"}
+#usermenu li:first-child:before{content:""}
+#usermenu li a{padding-left:4px}
 #topsearch{display:inline}
 #topsearch div{display:inline;font-size:.82em}
 #topsearch label{display:none}


### PR DESCRIPTION
A detail, that annoys me every time I visit the project forum is a bit of a background image, I see on the left bottom corner of the usermenu links. I replaced the CSS-background image with a pipe, inserted with `#usermenu li:before`.

![mlf2-annoying-images](https://cloud.githubusercontent.com/assets/1734660/19116266/24812412-8b15-11e6-9a11-af2eaf1c8c24.png)

The upper part is a screenshot from the project forum, the lower one with the fix is a screenshot from my test installation.

