### PR TITLE
save read status to table

### DIFF
--- a/includes/entry.inc.php
+++ b/includes/entry.inc.php
@@ -46,17 +46,18 @@ if(isset($id) && $id > 0)
       }
 
 	 if(isset($_SESSION[$settings['session_prefix'].'user_id'])) {
+		 // bookmark handling
 		 $user_id  = $_SESSION[$settings['session_prefix'].'user_id'];
 		 $result   = mysqli_query($connid, "SELECT TRUE AS 'bookmark' FROM ".$db_settings['bookmark_table']." WHERE `user_id` = ".intval($user_id)." AND `posting_id` = ".intval($id)."") or raise_error('database_error',mysqli_error($connid));
 		 $bookmark = mysqli_fetch_row($result);
 		 mysqli_free_result($result);
 		 if (isset($bookmark) && intval($bookmark) == 1)
-			 $entrydata['bookmarkedby'] = intval($user_id);
-	 } 
-	  
-     if(isset($settings['count_views']) && $settings['count_views'] == 1) mysqli_query($connid, "UPDATE ".$db_settings['forum_table']." SET time=time, last_reply=last_reply, edited=edited, views=views+1 WHERE id=".$id);
+				$entrydata['bookmarkedby'] = intval($user_id);
+		 // read-status handling
+		 $rstatus = save_read_status($connid, $user_id, $id);
+	 }
 
-     save_read(set_read($id));
+     if(isset($settings['count_views']) && $settings['count_views'] == 1) mysqli_query($connid, "UPDATE ".$db_settings['forum_table']." SET time=time, last_reply=last_reply, edited=edited, views=views+1 WHERE id=".$id);
 
      if($entrydata['user_id'] > 0)
       {

--- a/includes/entry.inc.php
+++ b/includes/entry.inc.php
@@ -48,9 +48,9 @@ if(isset($id) && $id > 0)
 	 if(isset($_SESSION[$settings['session_prefix'].'user_id'])) {
 		 // bookmark handling
 		 $user_id  = $_SESSION[$settings['session_prefix'].'user_id'];
-		 $result   = mysqli_query($connid, "SELECT TRUE AS 'bookmark' FROM ".$db_settings['bookmark_table']." WHERE `user_id` = ".intval($user_id)." AND `posting_id` = ".intval($id)."") or raise_error('database_error',mysqli_error($connid));
-		 $bookmark = mysqli_fetch_row($result);
-		 mysqli_free_result($result);
+		 $bookmark_result = mysqli_query($connid, "SELECT TRUE AS 'bookmark' FROM ".$db_settings['bookmark_table']." WHERE `user_id` = ".intval($user_id)." AND `posting_id` = ".intval($id)."") or raise_error('database_error',mysqli_error($connid));
+		 $bookmark = mysqli_fetch_row($bookmark_result);
+		 mysqli_free_result($bookmark_result);
 		 if (isset($bookmark) && intval($bookmark) == 1)
 				$entrydata['bookmarkedby'] = intval($user_id);
 		 // read-status handling

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -264,17 +264,20 @@ function save_read($save_db=true)
 /**
  * saves the status "entry read" to the database table "mlf2_read_entries"
  *
- * @param int $entry, ID of the entry itself
  * @param resource $connid, ID of the database connection
+ * @param int $user_id, ID of the registered, actually acting user
+ * @param int $entry, ID of the entry itself
+ *
  * @return boolean $ret, success: true, else: false
  */
-function save_read_status($entry = 0, $connid) {
+function save_read_status($connid, $user_id, $entry_id) {
 	global $settings, $db_settings;
 	$ret = false;
 	$entry = intval($entry);
-	if (!is_numeric($entry)) return false;
-	if (isset($_SESSION[$settings['session_prefix'].'user_id']) and $entry > 0) {
-		$ret = @mysqli_query($connid, "INSERT INTO ". $db_settings['read_status_table'] ." (user_id, posting_id, time) VALUES (". intval($_SESSION[$settings['session_prefix'].'user_id']) .", ". $entry .", NOW()) ON DUPLICATE KEY UPDATE time = NOW()");
+	$user_id = intval($user_id)
+;	if (!is_numeric($entry)) return false;
+	if ($_SESSION[$settings['session_prefix'].'user_id'] === $user_id and $entry > 0) {
+		$ret = @mysqli_query($connid, "INSERT INTO ". $db_settings['read_status_table'] ." (user_id, posting_id, time) VALUES (". $user_id .", ". $entry .", NOW()) ON DUPLICATE KEY UPDATE time = NOW()");
 	}
 	return $ret;
 }

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -273,11 +273,11 @@ function save_read($save_db=true)
 function save_read_status($connid, $user_id, $entry_id) {
 	global $settings, $db_settings;
 	$ret = false;
-	$entry = intval($entry);
-	$user_id = intval($user_id)
-;	if (!is_numeric($entry)) return false;
-	if ($_SESSION[$settings['session_prefix'].'user_id'] === $user_id and $entry > 0) {
-		$ret = @mysqli_query($connid, "INSERT INTO ". $db_settings['read_status_table'] ." (user_id, posting_id, time) VALUES (". $user_id .", ". $entry .", NOW()) ON DUPLICATE KEY UPDATE time = NOW()");
+	$entry_id = intval($entry_id);
+	$user_id = intval($user_id);
+	if (!is_numeric($entry_id)) return false;
+	if (intval($_SESSION[$settings['session_prefix'].'user_id']) === $user_id and $entry_id > 0) {
+		$ret = @mysqli_query($connid, "INSERT INTO ". $db_settings['read_status_table'] ." (user_id, posting_id, time) VALUES (". $user_id .", ". $entry_id .", NOW()) ON DUPLICATE KEY UPDATE time = NOW()");
 	}
 	return $ret;
 }

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -262,6 +262,24 @@ function save_read($save_db=true)
  }
 
 /**
+ * saves the status "entry read" to the database table "mlf2_read_entries"
+ *
+ * @param int $entry, ID of the entry itself
+ * @param resource $connid, ID of the database connection
+ * @return boolean $ret, success: true, else: false
+ */
+function save_read_status($entry = 0, $connid) {
+	global $settings, $db_settings;
+	$ret = false;
+	$entry = intval($entry);
+	if (!is_numeric($entry)) return false;
+	if (isset($_SESSION[$settings['session_prefix'].'user_id']) and $entry > 0) {
+		$ret = @mysqli_query($connid, "INSERT INTO ". $db_settings['read_status_table'] ." (user_id, posting_id, time) VALUES (". intval($_SESSION[$settings['session_prefix'].'user_id']) .", ". $entry .", NOW()) ON DUPLICATE KEY UPDATE time = NOW()");
+	}
+	return $ret;
+}
+
+/**
  * generates an array of thread items for the navigation within a thread
  *
  * @param array $child_array

--- a/includes/thread.inc.php
+++ b/includes/thread.inc.php
@@ -242,17 +242,19 @@ else $order = 'time';
       else $data['views']=0;
 
 		if(isset($_SESSION[$settings['session_prefix'].'user_id'])) {
-			$bookmark_result = mysqli_query($connid, "SELECT TRUE AS 'bookmark' FROM ".$db_settings['bookmark_table']." WHERE `user_id` = ".intval($_SESSION[$settings['session_prefix'].'user_id'])." AND `posting_id` = ".intval($data['id'])."") or raise_error('database_error',mysqli_error($connid));
+			// bookmark handling
+			$user_id  = $_SESSION[$settings['session_prefix'].'user_id'];
+			$bookmark_result = mysqli_query($connid, "SELECT TRUE AS 'bookmark' FROM ".$db_settings['bookmark_table']." WHERE `user_id` = ".intval($user_id)." AND `posting_id` = ".intval($data['id'])."") or raise_error('database_error',mysqli_error($connid));
 			$bookmark = mysqli_fetch_row($bookmark_result);
 			mysqli_free_result($bookmark_result);
 			if (isset($bookmark) && intval($bookmark) == 1) {
-				$data['bookmarkedby'] = intval($_SESSION[$settings['session_prefix'].'user_id']);
+				$data['bookmarkedby'] = intval($user_id);
 				$data['options']['delete_bookmark'] = true;
 			}
 			else
 				$data['options']['add_bookmark'] = true;
-		} 
-	  
+		}
+
 	  $data_array[$data["id"]] = $data;
       $child_array[$data["pid"]][] =  $data["id"];
      }

--- a/includes/thread.inc.php
+++ b/includes/thread.inc.php
@@ -253,6 +253,8 @@ else $order = 'time';
 			}
 			else
 				$data['options']['add_bookmark'] = true;
+			// read-status handling
+			$rstatus = save_read_status($connid, $user_id, $data['id']);
 		}
 
 	  $data_array[$data["id"]] = $data;
@@ -260,7 +262,6 @@ else $order = 'time';
      }
     mysqli_free_result($result);
 
-    save_read(set_read($new_read));
     }
     else
      {


### PR DESCRIPTION
The read status will be written to the table `mlf2_read_status` on every request for an entry (`includes/entry.inc.php` and `includes/thread.inc.php`).