### PR TITLE
Fix: don't add column id (PK, Auto Increment) …

### DIFF
--- a/install/install.sql
+++ b/install/install.sql
@@ -12,7 +12,7 @@ CREATE TABLE mlf2_logincontrol (time timestamp NOT NULL default CURRENT_TIMESTAM
 CREATE TABLE mlf2_entries_cache (cache_id int(11) NOT NULL, cache_text mediumtext NOT NULL, PRIMARY KEY (cache_id)) CHARSET=utf8 COLLATE=utf8_general_ci;
 CREATE TABLE mlf2_userdata_cache (cache_id int(11) NOT NULL, cache_signature text NOT NULL, cache_profile text NOT NULL, PRIMARY KEY (cache_id)) CHARSET=utf8 COLLATE=utf8_general_ci;
 CREATE TABLE mlf2_bookmarks (id int(11) NOT NULL AUTO_INCREMENT, user_id int(11) NOT NULL, posting_id int(11) NOT NULL, time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, subject varchar(255) NOT NULL, order_id int(11) NOT NULL DEFAULT '0', PRIMARY KEY (id), UNIQUE KEY UNIQUE_uid_pid (user_id,posting_id)) CHARSET=utf8 COLLATE=utf8_general_ci;
-CREATE TABLE mlf2_read_entries (id bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT, user_id int(11) UNSIGNED NOT NULL, posting_id int(11) UNSIGNED NOT NULL, time timestamp NOT NULL, PRIMARY KEY (id), UNIQUE KEY read_per_user (user_id, posting_id)) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+CREATE TABLE mlf2_read_entries (user_id int(11) UNSIGNED NOT NULL, posting_id int(11) UNSIGNED NOT NULL, time timestamp NOT NULL, UNIQUE KEY read_per_user (user_id, posting_id)) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 INSERT INTO mlf2_banlists VALUES ('user_agents', '');

--- a/update/update.sql
+++ b/update/update.sql
@@ -334,6 +334,6 @@ UPDATE mlf2_settings SET value = '2.3.7' WHERE name = 'version';
 -- 2.3.7 to 2.4.0
 /*
 CREATE TABLE mlf2_bookmarks (id int(11) NOT NULL AUTO_INCREMENT,user_id int(11) NOT NULL,posting_id int(11) NOT NULL,time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,subject varchar(255) NOT NULL,order_id int(11) NOT NULL DEFAULT '0',PRIMARY KEY (id),UNIQUE KEY UNIQUE_uid_pid (user_id,posting_id));
-CREATE TABLE mlf2_read_entries (id bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT, user_id int(11) UNSIGNED NOT NULL, posting_id int(11) UNSIGNED NOT NULL, time timestamp NOT NULL, PRIMARY KEY (id), UNIQUE KEY read_per_user (user_id, posting_id)) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+CREATE TABLE mlf2_read_entries (user_id int(11) UNSIGNED NOT NULL, posting_id int(11) UNSIGNED NOT NULL, time timestamp NOT NULL, UNIQUE KEY read_per_user (user_id, posting_id)) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 UPDATE mlf2_settings SET value = '2.4.0' WHERE name = 'version';
 */

--- a/update/update_2.3.5-2.4.php
+++ b/update/update_2.3.5-2.4.php
@@ -190,7 +190,7 @@ if(empty($update['errors']) && in_array($settings['version'],array('2.0 RC 1','2
 			if(!@mysqli_query($connid, "CREATE TABLE ".$db_settings['bookmark_table']." (id int(11) NOT NULL AUTO_INCREMENT,user_id int(11) NOT NULL,posting_id int(11) NOT NULL,time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,subject varchar(255) NOT NULL,order_id int(11) NOT NULL DEFAULT '0',PRIMARY KEY (id),UNIQUE KEY UNIQUE_uid_pid (user_id,posting_id)) CHARSET=utf8 COLLATE=utf8_general_ci")) {
 				$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			}
-			if(!@mysqli_query($connid, "CREATE TABLE ".$db_settings['read_status_table']." (id bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT, user_id int(11) UNSIGNED NOT NULL, posting_id int(11) UNSIGNED NOT NULL, time timestamp NOT NULL, PRIMARY KEY (id), UNIQUE KEY read_per_user (user_id, posting_id)) ENGINE=InnoDB DEFAULT CHARSET=utf8;")) {
+			if(!@mysqli_query($connid, "CREATE TABLE ".$db_settings['read_status_table']." (user_id int(11) UNSIGNED NOT NULL, posting_id int(11) UNSIGNED NOT NULL, time timestamp NOT NULL, UNIQUE KEY read_per_user (user_id, posting_id)) ENGINE=InnoDB DEFAULT CHARSET=utf8;")) {
 				$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			}
 		}


### PR DESCRIPTION
… when `read_per_user` is an unique index.

To add the column `id` was a counterproductive decision because it causes problems when using MySQL's `INSERT ON DUPLICATE INDEX UPDATE`. If an entry was requested a few times without a request for a different entry in the meantime, the primary key was incremented and the next request for a *not stored* user_id-posting_id combination got a unnecessary high index (column `id`). The unique index `read_per_user` as a combination of `user_id` and `posting_id` is index enough.