### PR TITLE
Fix: trigger login control with all setting values > 0

### DIFF
--- a/includes/auto_login.inc.php
+++ b/includes/auto_login.inc.php
@@ -90,19 +90,19 @@ if(empty($_SESSION[$settings['session_prefix'].'user_id']) && isset($_COOKIE[$se
        }
       else
        {
-        if($settings['temp_block_ip_after_repeated_failed_logins']==1) count_failed_logins();
+        if($settings['temp_block_ip_after_repeated_failed_logins'] > 0) count_failed_logins();
         setcookie($settings['session_prefix'].'auto_login','',0);
        }
      }
     else
      {
-      if($settings['temp_block_ip_after_repeated_failed_logins']==1) count_failed_logins();
+      if($settings['temp_block_ip_after_repeated_failed_logins'] > 0) count_failed_logins();
       setcookie($settings['session_prefix'].'auto_login','',0);
      }
     }
    else
     {
-     if($settings['temp_block_ip_after_repeated_failed_logins']==1) count_failed_logins();
+     if($settings['temp_block_ip_after_repeated_failed_logins'] > 0) count_failed_logins();
      setcookie($settings['session_prefix'].'auto_login','',0);
     }
  }

--- a/includes/login.inc.php
+++ b/includes/login.inc.php
@@ -185,21 +185,21 @@ switch ($action)
         }
        else
         {
-         if($settings['temp_block_ip_after_repeated_failed_logins']==1) count_failed_logins();
+         if($settings['temp_block_ip_after_repeated_failed_logins'] > 0) count_failed_logins();
          $action = 'login';
          $login_message='login_failed';
         }
      }
     else
      {
-      if($settings['temp_block_ip_after_repeated_failed_logins']==1) count_failed_logins();
+      if($settings['temp_block_ip_after_repeated_failed_logins'] > 0) count_failed_logins();
       $action = 'login';
       $login_message='login_failed';
      }
     }
    else
     {
-     if($settings['temp_block_ip_after_repeated_failed_logins']==1) count_failed_logins();
+     if($settings['temp_block_ip_after_repeated_failed_logins'] > 0) count_failed_logins();
      $action = 'login';
      $login_message='login_failed';
     }


### PR DESCRIPTION
Setting `temp_block_ip_after_repeated_failed_logins` define the time limit,
if the value is greater than 0. That has to be respected, when the check should be triggered.