### PR TITLE
Change: alter settings table and rewrite the settings

### DIFF
--- a/install/install.sql
+++ b/install/install.sql
@@ -11,8 +11,8 @@ CREATE TABLE mlf2_useronline (ip char(15) NOT NULL default '',time int(14) NOT N
 CREATE TABLE mlf2_logincontrol (time timestamp NOT NULL default CURRENT_TIMESTAMP, ip varchar(255) NOT NULL default '', logins int(11) NOT NULL default '0') CHARSET=utf8 COLLATE=utf8_general_ci;
 CREATE TABLE mlf2_entries_cache (cache_id int(11) NOT NULL, cache_text mediumtext NOT NULL, PRIMARY KEY (cache_id)) CHARSET=utf8 COLLATE=utf8_general_ci;
 CREATE TABLE mlf2_userdata_cache (cache_id int(11) NOT NULL, cache_signature text NOT NULL, cache_profile text NOT NULL, PRIMARY KEY (cache_id)) CHARSET=utf8 COLLATE=utf8_general_ci;
-CREATE TABLE mlf2_bookmarks (id int(11) NOT NULL AUTO_INCREMENT, user_id int(11) NOT NULL, posting_id int(11) NOT NULL, time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, subject varchar(255) NOT NULL, order_id int(11) NOT NULL DEFAULT '0', PRIMARY KEY (id), UNIQUE KEY UNIQUE_uid_pid (user_id,posting_id)) CHARSET=utf8 COLLATE=utf8_general_ci;
-CREATE TABLE mlf2_read_entries (user_id int(11) UNSIGNED NOT NULL, posting_id int(11) UNSIGNED NOT NULL, time timestamp NOT NULL, PRIMARY KEY (user_id, posting_id)) CHARSET=utf8 COLLATE=utf8_general_ci;
+CREATE TABLE mlf2_bookmarks (id int(11) NOT NULL AUTO_INCREMENT, user_id int(11) NOT NULL, posting_id int(11) NOT NULL, time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, subject varchar(255) NOT NULL, order_id int(11) NOT NULL DEFAULT '0', PRIMARY KEY (id), UNIQUE KEY UNIQUE_uid_pid (user_id,posting_id)) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
+CREATE TABLE mlf2_read_entries (user_id int(11) UNSIGNED NOT NULL, posting_id int(11) UNSIGNED NOT NULL, time timestamp NOT NULL, PRIMARY KEY (user_id, posting_id)) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 INSERT INTO mlf2_banlists VALUES ('user_agents', '');
 INSERT INTO mlf2_banlists VALUES ('ips', '');

--- a/update/update_2.3.5-2.4.php
+++ b/update/update_2.3.5-2.4.php
@@ -187,10 +187,10 @@ if(empty($update['errors']) && in_array($settings['version'],array('2.0 RC 1','2
 			flock($db_settings_file, 3);
 			fclose($db_settings_file);
 			
-			if(!@mysqli_query($connid, "CREATE TABLE ".$db_settings['bookmark_table']." (id int(11) NOT NULL AUTO_INCREMENT,user_id int(11) NOT NULL,posting_id int(11) NOT NULL,time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,subject varchar(255) NOT NULL,order_id int(11) NOT NULL DEFAULT '0',PRIMARY KEY (id),UNIQUE KEY UNIQUE_uid_pid (user_id,posting_id)) CHARSET=utf8 COLLATE=utf8_general_ci")) {
+			if(!@mysqli_query($connid, "CREATE TABLE ".$db_settings['bookmark_table']." (id int(11) NOT NULL AUTO_INCREMENT,user_id int(11) NOT NULL,posting_id int(11) NOT NULL,time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,subject varchar(255) NOT NULL,order_id int(11) NOT NULL DEFAULT '0',PRIMARY KEY (id),UNIQUE KEY UNIQUE_uid_pid (user_id,posting_id)) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci")) {
 				$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			}
-			if(!@mysqli_query($connid, "CREATE TABLE ".$db_settings['read_status_table']." (user_id int(11) UNSIGNED NOT NULL, posting_id int(11) UNSIGNED NOT NULL, time timestamp NOT NULL, PRIMARY KEY (user_id, posting_id)) CHARSET=utf8 COLLATE=utf8_general_ci;")) {
+			if(!@mysqli_query($connid, "CREATE TABLE ".$db_settings['read_status_table']." (user_id int(11) UNSIGNED NOT NULL, posting_id int(11) UNSIGNED NOT NULL, time timestamp NOT NULL, PRIMARY KEY (user_id, posting_id)) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;")) {
 				$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			}
 			// rework the settings table, add primary key, restore the settings

--- a/update/update_2.3.5-2.4.php
+++ b/update/update_2.3.5-2.4.php
@@ -186,7 +186,7 @@ if(empty($update['errors']) && in_array($settings['version'],array('2.0 RC 1','2
 			fwrite($db_settings_file, "?".">\n");
 			flock($db_settings_file, 3);
 			fclose($db_settings_file);
-			
+			// new tables
 			if(!@mysqli_query($connid, "CREATE TABLE ".$db_settings['bookmark_table']." (id int(11) NOT NULL AUTO_INCREMENT,user_id int(11) NOT NULL,posting_id int(11) NOT NULL,time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,subject varchar(255) NOT NULL,order_id int(11) NOT NULL DEFAULT '0',PRIMARY KEY (id),UNIQUE KEY UNIQUE_uid_pid (user_id,posting_id)) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci")) {
 				$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			}
@@ -213,7 +213,7 @@ if(empty($update['errors']) && in_array($settings['version'],array('2.0 RC 1','2
 			if(!@mysqli_query($connid, "INSERT INTO `".$db_settings['settings_table']."` (`name`, `value`) VALUES ('read_state_expiration_date', '150') ON DUPLICATE KEY UPDATE `value` = `value`")) {
 				$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			}
-
+			// transfer the IDs of the read entries from the user data to the new read status table
 			$numberOfStoredEntriesResult = @mysqli_query($connid, "SELECT `value` FROM `".$db_settings['settings_table']."` WHERE `name` = 'max_read_items' LIMIT 1");
 			if(mysqli_num_rows($numberOfStoredEntriesResult) == 1) {
 				$numberOfStoredEntriesValues = mysqli_fetch_array($numberOfStoredEntriesResult);

--- a/update/update_2.3.5-2.4.php
+++ b/update/update_2.3.5-2.4.php
@@ -232,11 +232,6 @@ if(empty($update['errors']) && in_array($settings['version'],array('2.0 RC 1','2
 					$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 				}
 			}
-
-			if(!@mysqli_query($connid, "DELETE FROM `".$db_settings['settings_table']."` WHERE `name` = 'auto_lock_old_threads' LIMIT 1;")) {
-				$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-			}
-			
 		}
 	}
 	else {

--- a/update/update_2.3.5-2.4.php
+++ b/update/update_2.3.5-2.4.php
@@ -210,7 +210,7 @@ if(empty($update['errors']) && in_array($settings['version'],array('2.0 RC 1','2
 				}
 			}
 			// add a new setting for the duration an entry will be marked as read
-			if(!@mysqli_query($connid, "INSERT INTO `".$db_settings['settings_table']."` (`name`, `value`) VALUES ('read_state_expiration_date', '150');")) {
+			if(!@mysqli_query($connid, "INSERT INTO `".$db_settings['settings_table']."` (`name`, `value`) VALUES ('read_state_expiration_date', '150') ON DUPLICATE KEY UPDATE `value` = `value`")) {
 				$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			}
 


### PR DESCRIPTION
Alternatively, more general attempt for a solution of #99. See also PR #112 

The datasets from the settings table will be transferred into an array. Keys with identic names will overwrite each other, so it ends with onle line per setting. After altering the table structure (PK and table type), the settings will be written back into the table.

Any thoughts?