### PR TITLE
Fix: a new entry can't be read and a read one can't be new

### DIFF
--- a/includes/index.inc.php
+++ b/includes/index.inc.php
@@ -128,21 +128,6 @@ if($result_count > 0)
       // convert formated time to a utf-8:
       $data['formated_time'] = format_time($lang['time_format'],$data['timestamp']);
 
-      if($data['pid']==0)
-       {
-        if(isset($_SESSION[$settings['session_prefix'].'usersettings']['newtime']) && $_SESSION[$settings['session_prefix'].'usersettings']['newtime']<$data['last_reply'] || $last_visit && $data['last_reply'] > $last_visit) $data['new'] = true;
-        else $data['new'] = false;
-       }
-      else
-       { 
-        if(isset($_SESSION[$settings['session_prefix'].'usersettings']['newtime']) && $_SESSION[$settings['session_prefix'].'usersettings']['newtime']<$data['time'] || $last_visit && $data['time'] > $last_visit) $data['new'] = true;
-        else $data['new'] = false;
-       }
-      if ($data['req_user'] !== NULL and is_numeric($data['req_user'])) {
-       $data['is_read'] = true;
-      } else {
-       $data['is_read'] = false;
-      }
 
       if($data['pid']==0) $threads[] = $data['id'];
       $data_array[$data['id']] = $data;
@@ -152,6 +137,23 @@ if($result_count > 0)
    }
   @mysqli_free_result($result);
  }
+			if ($data['req_user'] !== NULL and is_numeric($data['req_user'])) {
+				$data['is_read'] = true;
+				$data['new'] = false;
+			} else {
+				if (isset($_SESSION[$settings['session_prefix'].'user_id'])) {
+					$data['is_read'] = false;
+					$data['new'] = true;
+				} else {
+					if (isset($_SESSION[$settings['session_prefix'].'usersettings']['newtime']) && $_SESSION[$settings['session_prefix'].'usersettings']['newtime'] < $data['time'] || ($last_visit && ($data['last_reply'] > $last_visit or $data['time'] > $last_visit))) {
+						$data['is_read'] = false;
+						$data['new'] = true;
+					} else {
+						$data['is_read'] = true;
+						$data['new'] = false;
+					}
+				}
+			}
 
 // latest postings:
 if($settings['latest_postings']>0)

--- a/includes/thread.inc.php
+++ b/includes/thread.inc.php
@@ -107,10 +107,6 @@ else $order = 'time';
        }
 
       $data['formated_time'] = format_time($lang['time_format_full'],$data['disp_time']);
-      
-      if(isset($_SESSION[$settings['session_prefix'].'usersettings']['newtime']) && $_SESSION[$settings['session_prefix'].'usersettings']['newtime']<$data['time'] || $last_visit && $data['time'] > $last_visit) $data['new'] = true;
-      else $data['new'] = false;
-      
       $ago['days'] = floor((TIMESTAMP - $data['time'])/86400);
       $ago['hours'] = floor(((TIMESTAMP - $data['time'])/3600)-($ago['days']*24));
       $ago['minutes'] = floor(((TIMESTAMP - $data['time'])/60)-($ago['hours']*60+$ago['days']*1440));
@@ -259,11 +255,23 @@ else $order = 'time';
 			// read-status handling
 			$rstatus = save_read_status($connid, $user_id, $data['id']);
 		}
-     if ($data['req_user'] !== NULL and is_numeric($data['req_user'])) {
-       $data['is_read'] = true;
-     } else {
-       $data['is_read'] = false;
-     }
+			if ($data['req_user'] !== NULL and is_numeric($data['req_user'])) {
+				$data['is_read'] = true;
+				$data['new'] = false;
+			} else {
+				if (isset($_SESSION[$settings['session_prefix'].'user_id'])) {
+					$data['is_read'] = false;
+					$data['new'] = true;
+				} else {
+					if (isset($_SESSION[$settings['session_prefix'].'usersettings']['newtime']) && $_SESSION[$settings['session_prefix'].'usersettings']['newtime'] < $data['time'] || ($last_visit && ($data['last_reply'] > $last_visit or $data['time'] > $last_visit))) {
+						$data['is_read'] = false;
+						$data['new'] = true;
+					} else {
+						$data['is_read'] = true;
+						$data['new'] = false;
+					}
+				}
+			}
 
 	  $data_array[$data["id"]] = $data;
       $child_array[$data["pid"]][] =  $data["id"];


### PR DESCRIPTION
An entry is either new or read but it can't be both.
Use the new read status for registered users and the old
cookie based behaviour for not registered visitors.