### PR TITLE
Extract Download-URI from ATOM-Feed

### DIFF
--- a/includes/admin.inc.php
+++ b/includes/admin.inc.php
@@ -2020,12 +2020,18 @@ $smarty->assign('install_script_exists', file_exists('./install/index.php'));
 
 // Pruefe, ob eine neue Version zur Verfuegung steht
 $lastVersionCheck = false;
-$lastVersionCheck = @mysqli_query($connid, "SELECT value AS version FROM ".$db_settings['temp_infos_table']." WHERE name = 'last_version_check'");
+$lastVersionURI   = false;
+$lastVersionCheck = @mysqli_query($connid, "SELECT `value` AS `version` FROM `".$db_settings['temp_infos_table']."` WHERE `name` = 'last_version_check'");
+$lastVersionURI   = @mysqli_query($connid, "SELECT `value` AS `uri` FROM `".$db_settings['temp_infos_table']."` WHERE `name` = 'last_version_uri'");
 
-if (($lastVersionCheck !== false and mysqli_num_rows($lastVersionCheck) == 1) and (isset($settings) && isset($settings['version']))) {
+if (($lastVersionCheck !== false && mysqli_num_rows($lastVersionCheck) == 1) && ($lastVersionURI !== false and mysqli_num_rows($lastVersionURI) == 1) && (isset($settings) && isset($settings['version']))) {
 	$lastVC = mysqli_fetch_assoc($lastVersionCheck);
+	$lastVU = mysqli_fetch_assoc($lastVersionURI);
 	mysqli_free_result($lastVersionCheck);
+	mysqli_free_result($lastVersionURI);
+
 	if ($lastVC !== NULL) {
+		$smarty->assign('latest_release_uri', $lastVU == NULL ? "https://github.com/ilosuna/mylittleforum/releases/latest" : htmlspecialchars($lastVU['uri']));		
 		$smarty->assign('latest_release_version', htmlspecialchars($lastVC['version']));
 	}
 }

--- a/themes/default/subtemplates/admin.inc.tpl
+++ b/themes/default/subtemplates/admin.inc.tpl
@@ -1094,7 +1094,11 @@
 	<div id="admin-info-releases">
 	{if $latest_release_version}
 		<h3>{#releases_info_header#}</h3>
-		<p><a href="https://github.com/ilosuna/mylittleforum/releases/latest">Download {$latest_release_version}</a></p>
+		{if $latest_release_uri}
+			<p><a href="{$latest_release_uri}">Download {$latest_release_version}</a></p>
+		{else}
+			<p><a href="https://github.com/ilosuna/mylittleforum/releases/latest">Download {$latest_release_version}</a></p>
+		{/if}
 	{else}
 		<h3>{#releases_info_header#}</h3>
 		<p><a href="https://github.com/ilosuna/mylittleforum/releases/latest">{#releases_list_link#}</a></p>


### PR DESCRIPTION
- Download/info uri is extracted from ATOM using LINK-element
- RegEx to get the version is updated to match both: '1.2.3' and 'v1.2.3'
- URI is stored in 'temp_infos_table' as 'last_version_uri'
- see: https://github.com/ilosuna/mylittleforum/issues/155