### PR TITLE
PHP-Object problem

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2671,13 +2671,14 @@ function checkUpdate($currentVersion = '0.0') {
 			$title      = $xml->xpath("//atom:entry[1]/atom:title/text()");
 			$content    = $xml->xpath("//atom:entry[1]/atom:content/text()");
 			$releaseURI = $xml->xpath("//atom:entry[1]/atom:link/@href");
-
-			$release = (object) [
+			
+			$release = (object) array(
 				'title'   => (string)$title[0],
 				'content' => (string)$content[0],
 				'version' => (string)$lastVersion,
 				'uri'     => $baseURI . (string)$releaseURI[0]->href
-			];
+			);
+
 			return $release;
 		}
 	}


### PR DESCRIPTION
- PHP object is initialized by an array-type to be valid with PHP 5.2 and 5.3.
- see https://github.com/ilosuna/mylittleforum/issues/169
- see http://mylittleforum.net/forum/index.php?id=9828