### PR TITLE
pre-populate the field for forum-URL with the correct protocol string

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2810,6 +2810,18 @@ function getAvatar($user_id) {
 }
 
 /**
+ * check, if HTTPS was used for the current request
+ *
+ * @return boolean
+ */
+function getURLProtocol() {
+	if ((!empty($_SERVER['HTTPS']) and $_SERVER['HTTPS'] !== 'off') or (!empty($_SERVER['SERVER_PORT']) and $_SERVER['SERVER_PORT'] == 443)) {
+		return true;
+	}
+	return false;
+}
+
+/**
  * sends a status code, displays an error message and halts the script
  *
  * @param string $status_code

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2814,7 +2814,7 @@ function getAvatar($user_id) {
  *
  * @return boolean
  */
-function getURLProtocol() {
+function isProtocolHTTPS() {
 	if ((!empty($_SERVER['HTTPS']) and $_SERVER['HTTPS'] !== 'off') or (!empty($_SERVER['SERVER_PORT']) and $_SERVER['SERVER_PORT'] == 443)) {
 		return true;
 	}

--- a/install/index.php
+++ b/install/index.php
@@ -20,13 +20,13 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.        *
 *******************************************************************************/
 
-$default_settings['forum_name'] = 'my little forum';
-$default_settings['forum_address'] = 'http://'.$_SERVER['HTTP_HOST'].substr(rtrim(dirname($_SERVER['PHP_SELF']), '/\\'),0,strrpos(rtrim(dirname($_SERVER['PHP_SELF']), '/\\'),'/')).'/';
-$default_settings['table_prefix'] = 'mlf2_';
-
 define('IN_INDEX', TRUE);
 include('../config/db_settings.php');
 include('../includes/functions.inc.php');
+
+$default_settings['forum_name'] = 'my little forum';
+$default_settings['forum_address'] = ((getURLProtocol() === true) ? 'https' : 'http') .'://'. $_SERVER['HTTP_HOST'] . substr(rtrim(dirname($_SERVER['SCRIPT_NAME']), '/\\'), 0, strrpos(rtrim(dirname($_SERVER['SCRIPT_NAME']), '/\\'), '/')) . '/';
+$default_settings['table_prefix'] = 'mlf2_';
 
 // stripslashes on GPC if get_magic_quotes_gpc is enabled:
 if(get_magic_quotes_gpc())

--- a/install/index.php
+++ b/install/index.php
@@ -25,7 +25,7 @@ include('../config/db_settings.php');
 include('../includes/functions.inc.php');
 
 $default_settings['forum_name'] = 'my little forum';
-$default_settings['forum_address'] = ((getURLProtocol() === true) ? 'https' : 'http') .'://'. $_SERVER['HTTP_HOST'] . substr(rtrim(dirname($_SERVER['SCRIPT_NAME']), '/\\'), 0, strrpos(rtrim(dirname($_SERVER['SCRIPT_NAME']), '/\\'), '/')) . '/';
+$default_settings['forum_address'] = ((isProtocolHTTPS() === true) ? 'https' : 'http') .'://'. $_SERVER['HTTP_HOST'] . substr(rtrim(dirname($_SERVER['SCRIPT_NAME']), '/\\'), 0, strrpos(rtrim(dirname($_SERVER['SCRIPT_NAME']), '/\\'), '/')) . '/';
 $default_settings['table_prefix'] = 'mlf2_';
 
 // stripslashes on GPC if get_magic_quotes_gpc is enabled:


### PR DESCRIPTION
It's for convenience of the potential forum admins that want's to install MLF and run it HTTPS-based.