### PR TITLE
Fix: allow e-mail-addresses with TLDs longer than 4 chars

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -375,18 +375,15 @@ function is_valid_url($url)
  * @param string $email
  * @return bool
  */
-function is_valid_email($email)
- {
-  if(!preg_match("/^([\w-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([\w-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$/", $email))
-   {
-    return false;
-   }
-  if(contains_invalid_string($email))
-   {
-    return false;
-   }
-  return true;
- }
+function is_valid_email($email) {
+	if (!preg_match("/^([\w-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([\w-]+\.)+))([a-zA-Z]{2,}|[0-9]{1,3})(\]?)$/", $email)) {
+		return false;
+	}
+	if (contains_invalid_string($email)) {
+		return false;
+	}
+	return true;
+}
 
 /**
  * help function for is_valid_url() and is_valid_email()


### PR DESCRIPTION
Top level domains with more than 4 chars are present since far more than ten years ([.museum](https://en.wikipedia.org/wiki/.museum) started back in 2001). So either the regular expression has to altered or the PHP-function `filter_var`, which is much more generic, has to be used.

After reading the user contributed notes in the PHP documentation page for [the function filter_var](https://secure.php.net/filter_var) I decided against `filter_var` and to alter the regular expression instead. The use of `filter_var` for e-mail-validation can cause false negatives because the function can't handle puny-code domain-names (domain names with non latin chars). That's a no go nowadays (IMHO).

The regular expression allows now TLDs with *two **or more** chars*.