### PR TITLE
Fix: mention the check for the actual version of config/VERSION

### DIFF
--- a/update/update_2.3.5-2.4.php
+++ b/update/update_2.3.5-2.4.php
@@ -159,7 +159,7 @@ if(!file_exists('config/VERSION')) {
 if (empty($update['errors'])) {
 	$newVersion = trim(file_get_contents('config/VERSION'));
 	if ($newVersion <= $settings['version']) {
-		$update['errors'][] = 'Error in line '.__LINE__.': The version you want to install (see string in config/VERSION) must be greater than the current installed version. Current version: '. htmlspecialchars($settings['version']) .', version you want to install: '.  htmlspecialchars($newVersion) .'.';
+		$update['errors'][] = 'Error in line '.__LINE__.': The version you want to install (see string in config/VERSION) must be greater than the current installed version. Current version: '. htmlspecialchars($settings['version']) .', version you want to install: '.  htmlspecialchars($newVersion) .'. Please check also if you uploaded the actual file version of config/VERSION. Search therefore for the file date and compare it with the date from the installation package.';
 	}
 	if(!in_array($settings['version'], $update['version'])) {
 		$update['errors'][] = 'Error in line '.__LINE__.': This update file doesn\'t work with the current version.';


### PR DESCRIPTION
If the error message tells you, that the installed and new version share the same version number, it is possible, that you forgot to upload the file `config/VERSION`. The error message now includes this information.