### PR TITLE
Outsourcing of read- and new-status handling into a function

### DIFF
--- a/includes/entry.inc.php
+++ b/includes/entry.inc.php
@@ -148,37 +148,9 @@ if(isset($id) && $id > 0)
    $data['subject'] = htmlspecialchars($data['subject']);
    $data['formated_time'] = format_time($lang['time_format'],$data['disp_time']);
 
-    // Read state taken from thread.inc.php Line ~258
-	if ($data['req_user'] !== NULL and is_numeric($data['req_user'])) {
-		$data['is_read'] = true;
-		$data['new'] = false;
-	} else {
-		$data['is_read'] = false;
-		if (isset($_SESSION[$settings['session_prefix'].'usersettings']['newtime']) && $_SESSION[$settings['session_prefix'].'usersettings']['newtime'] < $data['time'] || ($last_visit && (isset($data['last_reply']) && $data['last_reply'] > $last_visit or isset($data['time']) && $data['time'] > $last_visit))) {
-			$data['new'] = true;
-		} else {
-			$data['new'] = false;
-		}
-	}
-   
-   
-   /*
-   if ($data['req_user'] !== NULL and is_numeric($data['req_user'])) {
-       $data['is_read'] = true;
-      } else {
-       $data['is_read'] = false;
-      }
-   if($data['pid']==0)
-    {
-     if(isset($_SESSION[$settings['session_prefix'].'usersettings']['newtime']) && $_SESSION[$settings['session_prefix'].'usersettings']['newtime']<$data['last_reply'] || $last_visit && $data['last_reply'] > $last_visit) $data['new'] = true;
-     else $data['new'] = false;
-    }
-   else
-    { 
-     if(isset($_SESSION[$settings['session_prefix'].'usersettings']['newtime']) && $_SESSION[$settings['session_prefix'].'usersettings']['newtime']<$data['time'] || $last_visit && $data['time'] > $last_visit) $data['new'] = true;
-     else $data['new'] = false;
-    }
-   */
+			// set read or new status of messages
+			$data = getMessageStatus($data, $last_visit);
+
    if($data['text']=='') $data['no_text'] = true;
    unset($data['text']);
 

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2822,6 +2822,29 @@ function isProtocolHTTPS() {
 }
 
 /**
+ * set the read or new status for a thread message
+ *
+ * @param array
+ * @param integer
+ * @return array
+ */
+function getMessageStatus($data, $lastVisit) {
+	global $settings;
+	if ($data['req_user'] !== NULL and is_numeric($data['req_user'])) {
+		$data['is_read'] = true;
+		$data['new'] = false;
+	} else {
+		$data['is_read'] = false;
+		if ((isset($_SESSION[$settings['session_prefix'].'usersettings']['newtime']) && $_SESSION[$settings['session_prefix'].'usersettings']['newtime'] < $data['time']) || ($lastVisit && ($data['last_reply'] > $lastVisit or $data['time'] > $lastVisit))) {
+			$data['new'] = true;
+		} else {
+			$data['new'] = false;
+		}
+	}
+	return $data;
+}
+
+/**
  * sends a status code, displays an error message and halts the script
  *
  * @param string $status_code

--- a/includes/index.inc.php
+++ b/includes/index.inc.php
@@ -124,17 +124,8 @@ if($result_count > 0)
 
       $data['subject'] = htmlspecialchars($data['subject']);
       if(isset($categories[$data['category']]) && $categories[$data['category']]!='') $data['category_name']=$categories[$data['category']];
-			if ($data['req_user'] !== NULL and is_numeric($data['req_user'])) {
-				$data['is_read'] = true;
-				$data['new'] = false;
-			} else {
-				$data['is_read'] = false;
-				if (isset($_SESSION[$settings['session_prefix'].'usersettings']['newtime']) && $_SESSION[$settings['session_prefix'].'usersettings']['newtime'] < $data['time'] || ($last_visit && ($data['last_reply'] > $last_visit or $data['time'] > $last_visit))) {
-					$data['new'] = true;
-				} else {
-					$data['new'] = false;
-				}
-			}
+			// set read or new status of messages
+			$data = getMessageStatus($data, $last_visit);
 
       // convert formated time to a utf-8:
       $data['formated_time'] = format_time($lang['time_format'],$data['timestamp']);

--- a/includes/thread.inc.php
+++ b/includes/thread.inc.php
@@ -255,17 +255,9 @@ else $order = 'time';
 				// read-status handling
 				$rstatus = save_read_status($connid, $user_id, $data['id']);
 			}
-			if ($data['req_user'] !== NULL and is_numeric($data['req_user'])) {
-				$data['is_read'] = true;
-				$data['new'] = false;
-			} else {
-				$data['is_read'] = false;
-				if (isset($_SESSION[$settings['session_prefix'].'usersettings']['newtime']) && $_SESSION[$settings['session_prefix'].'usersettings']['newtime'] < $data['time'] || ($last_visit && (isset($data['last_reply']) && $data['last_reply'] > $last_visit or isset($data['time']) && $data['time'] > $last_visit))) {
-					$data['new'] = true;
-				} else {
-					$data['new'] = false;
-				}
-			}
+			// set read or new status of messages
+			$data = getMessageStatus($data, $last_visit);
+			
 			$data_array[$data["id"]] = $data;
 			$child_array[$data["pid"]][] =  $data["id"];
 		}


### PR DESCRIPTION
As a last step for the unification of the handling of the messages read- and new-status I implemented the proposal of @derletztekick from the discussion in the PR #251 thread. In my testing forum (with only three accounts) it seems to work without side effects *at first sight*. It might be a good idea to test it in a regulary forum.

With the function we'll have a unified behavior and in case of changes only one place to edit. I like your solution @derletztekick. Please take a look before merging the code. :-)