### PR TITLE
Fix: readded lost marking of the opening posting as new …

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2835,18 +2835,11 @@ function getMessageStatus($data, $lastVisit, $folded = false) {
 		$data['new'] = false;
 	} else {
 		$data['is_read'] = false;
-		if ($data['pid'] == 0 && $folded !== false) {
-			if ((isset($_SESSION[$settings['session_prefix'].'usersettings']['newtime']) && $_SESSION[$settings['session_prefix'].'usersettings']['newtime'] < $data['last_reply']) || ($last_visit && $data['last_reply'] > $last_visit)) {
-				$data['new'] = true;
-			} else {
-				$data['new'] = false;
-			}
-		} else {
-			if ((isset($_SESSION[$settings['session_prefix'].'usersettings']['newtime']) && $_SESSION[$settings['session_prefix'].'usersettings']['newtime'] < $data['time']) || ($last_visit && $data['time'] > $last_visit)) {
-				$data['new'] = true;
-			} else {
-				$data['new'] = false;
-			}
+		$data['new'] = false;
+		if (($data['pid'] == 0 && $folded !== false) && ((isset($_SESSION[$settings['session_prefix'].'usersettings']['newtime']) && isset($data['last_reply']) && $_SESSION[$settings['session_prefix'].'usersettings']['newtime'] < $data['last_reply']) || ($last_visit && $data['last_reply'] > $last_visit))) {
+			$data['new'] = true;
+		} else if ((isset($_SESSION[$settings['session_prefix'].'usersettings']['newtime']) && isset($data['time']) && $_SESSION[$settings['session_prefix'].'usersettings']['newtime'] < $data['time']) || ($last_visit && $data['time'] > $last_visit)) {
+			$data['new'] = true;
 		}
 	}
 	return $data;

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2828,17 +2828,25 @@ function isProtocolHTTPS() {
  * @param integer
  * @return array
  */
-function getMessageStatus($data, $lastVisit) {
+function getMessageStatus($data, $lastVisit, $folded = false) {
 	global $settings;
 	if ($data['req_user'] !== NULL and is_numeric($data['req_user'])) {
 		$data['is_read'] = true;
 		$data['new'] = false;
 	} else {
 		$data['is_read'] = false;
-		if ((isset($_SESSION[$settings['session_prefix'].'usersettings']['newtime']) && $_SESSION[$settings['session_prefix'].'usersettings']['newtime'] < $data['time']) || ($lastVisit && ($data['last_reply'] > $lastVisit or $data['time'] > $lastVisit))) {
-			$data['new'] = true;
+		if ($data['pid'] == 0 && $folded !== false) {
+			if ((isset($_SESSION[$settings['session_prefix'].'usersettings']['newtime']) && $_SESSION[$settings['session_prefix'].'usersettings']['newtime'] < $data['last_reply']) || ($last_visit && $data['last_reply'] > $last_visit)) {
+				$data['new'] = true;
+			} else {
+				$data['new'] = false;
+			}
 		} else {
-			$data['new'] = false;
+			if ((isset($_SESSION[$settings['session_prefix'].'usersettings']['newtime']) && $_SESSION[$settings['session_prefix'].'usersettings']['newtime'] < $data['time']) || ($last_visit && $data['time'] > $last_visit)) {
+				$data['new'] = true;
+			} else {
+				$data['new'] = false;
+			}
 		}
 	}
 	return $data;

--- a/includes/index.inc.php
+++ b/includes/index.inc.php
@@ -14,8 +14,8 @@ if(isset($_SESSION[$settings['session_prefix'].'user_id'])) {
 if(isset($_SESSION[$settings['session_prefix'].'usersettings']['user_view'])) $user_view = $_SESSION[$settings['session_prefix'].'usersettings']['user_view'];
 else $user_view = $settings['default_view'];
 
-if(isset($_SESSION[$settings['session_prefix'].'usersettings']['fold_threads'])) $fold_threads = $_SESSION[$settings['session_prefix'].'usersettings']['fold_threads'];
-else $fold_threads = $settings['fold_threads'];
+if(isset($_SESSION[$settings['session_prefix'].'usersettings']['fold_threads'])) $fold_threads = (boolean) $_SESSION[$settings['session_prefix'].'usersettings']['fold_threads'];
+else $fold_threads = (boolean) $settings['fold_threads'];
 
 if(isset($_SESSION[$settings['session_prefix'].'usersettings']['thread_order']))
  {
@@ -125,7 +125,7 @@ if($result_count > 0)
       $data['subject'] = htmlspecialchars($data['subject']);
       if(isset($categories[$data['category']]) && $categories[$data['category']]!='') $data['category_name']=$categories[$data['category']];
 			// set read or new status of messages
-			$data = getMessageStatus($data, $last_visit);
+			$data = getMessageStatus($data, $last_visit, $fold_threads);
 
       // convert formated time to a utf-8:
       $data['formated_time'] = format_time($lang['time_format'],$data['timestamp']);


### PR DESCRIPTION
… in case of a new answer. This is important for folded threads, where one can't see the presence of a new answer, when the opening posting (the in the list only visible entry) is not marked as "found existing new answer".

See also the discussion in issue #245 