### PR TITLE
Small privacy enhancement, don't send always a referrer

### DIFF
--- a/themes/default/main.tpl
+++ b/themes/default/main.tpl
@@ -8,6 +8,8 @@
 {if $mode=='posting'}
 <meta name="robots" content="noindex" />
 {/if}
+<meta name="referrer" value="origin" />
+<meta name="referrer" value="same-origin" />
 <meta name="generator" content="my little forum {$settings.version}" />
 <link rel="stylesheet" type="text/css" href="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/style.min.css" media="all" />
 {if $settings.rss_feed==1}<link rel="alternate" type="application/rss+xml" title="RSS" href="index.php?mode=rss" />{/if}


### PR DESCRIPTION
It's a small step for the privacy of the visitors of a forum. If users follows links to external sites, no referrer will be sent. Browsers, that implemented only the old draft, a shortened referrer with the requesting domain name will be sent.

1st meta element: old draft, see https://wiki.whatwg.org/wiki/Meta_referrer (for Edge, Safari)
2nd meta element: actual draft, see https://w3c.github.io/webappsec-referrer-policy/