### PR TITLE
Rework of the HTML-structure for the list of latest postings

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -123,15 +123,15 @@ select.small             { font-family:verdana,arial,sans-serif; font-size:0.82e
 #latest-postings h3      { font-size:0.69em; line-height:1.7em; font-weight:normal; margin:0; padding:0 5px; background:#d2ddea url(images/bg_gradient_x.png) repeat-x 0 -150px; }
 #latest-postings ul      { font-size:0.82em; list-style:none; margin:0; padding:0; }
 #latest-postings li      { margin:0; padding:0; line-height:1.5em; word-wrap:break-word; overflow:hidden; }
-#latest-postings li a    { font-size:0.82em; line-height:1.5em; color:#808080; text-decoration:none; display:block; margin:0; padding:3px 5px 3px 5px; }
-#latest-postings li a:hover
-                         { background:#efefef; text-decoration:none; }
-#latest-postings li a span
-                         { font-size:1.2em; line-height:1.5em; color:#0000cc; }
-#latest-postings li a:visited span
+#latest-postings li a    { font-size:0.82em; line-height:1.5em; text-decoration:none; display:block; margin:0; padding:3px 5px; }
+#latest-postings li a:visited, #latest-postings li a.read
+                         { background-color: #ffffff; }
+#latest-postings li a:visited .entry-title, #latest-postings li a.read .entry-title
                          { color:#000077; }
-#latest-postings li a:focus span, #latest-postings li a:hover span
-                         { text-decoration:underline; }
+#latest-postings li a:focus,#latest-postings li a:hover
+                         { background:#efefef; text-decoration:none; }
+#latest-postings li a .entry-date, #latest-postings li a.read .entry-date
+                         { font-size: 0.82em; color: #808080; }
 
 #tagcloud                { position:relative; margin:0 0 20px 20px; background:#f9f9f9; border:1px solid #bacbdf; padding:0; width:13em; }
 #tagcloud p              { margin:0; padding:5px; font-size:0.69em; line-height:1.5em; }

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -111,17 +111,17 @@ select.small             { font-family:verdana,arial,sans-serif; font-size:0.82e
 #pbmlf                   { clear:both; margin:0; padding:0 20px 11px 20px; text-align:center; font-size:0.69em; color:#808080; }
 #pbmlf a                 { color:#808080; text-decoration:none; }
 
-#sidebar                 { position:relative; float:right; margin:0; padding:0; }
+#sidebar                 { position:relative; width: 13em; float:right; margin:0; padding:0; }
 #sidebar div             { position:relative; z-index:2; }
 #sidebar h3.sidebar      { position:absolute; top:0; right:0; font-size:0.69em; line-height:1.7em; font-weight:normal; margin:0; padding:0 17px 0 5px; background:#d2ddea url(images/bg_gradient_x.png) repeat-x 0 -150px; border:1px solid #bacbdf; z-index:1; }
 #sidebar h3.sidebar a    { color:#000; text-decoration:none; z-index:2; }
 #sidebartoggle           { position:absolute; top:5px; right:4px; margin:0; padding:0; z-index:3; }
 
-#latest-postings         { position:relative; margin:0 0 20px 20px; background:#f9f9f9; border:1px solid #bacbdf; padding:0; width:13em; }
+#latest-postings         { position:relative; margin:0 0 20px 0; background:#f9f9f9; border:1px solid #bacbdf; padding:0; }
 #latest-postings a.hide-sidebar
                          { position:absolute; top:2px; right:4px; margin:0; padding:0; line-height:11px; }
 #latest-postings h3      { font-size:0.69em; line-height:1.7em; font-weight:normal; margin:0; padding:0 5px; background:#d2ddea url(images/bg_gradient_x.png) repeat-x 0 -150px; }
-#latest-postings ul      { font-size:0.82em; list-style:none; margin:0; padding:0; }
+#latest-postings ul      { max-width:100%; font-size:0.82em; list-style:none; margin:0; padding:0; }
 #latest-postings li      { margin:0; padding:0; line-height:1.5em; word-wrap:break-word; overflow:hidden; }
 #latest-postings li a    { background-color: #f0f0f0; line-height:1.5em; text-decoration:none; display:block; margin:0; padding:3px 5px; }
 #latest-postings li a:visited, #latest-postings li a.read
@@ -133,13 +133,13 @@ select.small             { font-family:verdana,arial,sans-serif; font-size:0.82e
 #latest-postings li a .entry-date, #latest-postings li a.read .entry-date
                          { font-size: 0.82em; color: #808080; }
 
-#tagcloud                { position:relative; margin:0 0 20px 20px; background:#f9f9f9; border:1px solid #bacbdf; padding:0; width:13em; }
+#tagcloud                { position:relative; margin:0 0 20px 0; background:#f9f9f9; border:1px solid #bacbdf; padding:0; }
 #tagcloud p              { margin:0; padding:5px; font-size:0.69em; line-height:1.5em; }
 #tagcloud a.hide-sidebar { position:absolute; top:2px; right:4px; margin:0; padding:0; line-height:11px; }
 #tagcloud h3             { font-size:0.69em; line-height:1.7em; font-weight:normal; margin:0; padding:0 5px; background:#d2ddea url(images/bg_gradient_x.png) repeat-x 0 -150px; }
 #tagcloud strong         { font-weight:bold; font-size:1.051em; }
 
-#modmenu                 { position:relative; margin:0 0 20px 20px; background:#f9f9f9; border:1px solid #bacbdf; width:13em; }
+#modmenu                 { position:relative; margin:0 0 20px 0; background:#f9f9f9; border:1px solid #bacbdf; }
 #modmenu h3              { font-size:0.69em; line-height:1.7em; font-weight:normal; margin:0; padding:0 5px; background:#d2ddea url(images/bg_gradient_x.png) repeat-x 0 -150px; }
 
 #mod-options             { list-style:none; margin:0; padding:5px; font-size:0.69em !important; line-height:1.7em !important; }

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -123,7 +123,7 @@ select.small             { font-family:verdana,arial,sans-serif; font-size:0.82e
 #latest-postings h3      { font-size:0.69em; line-height:1.7em; font-weight:normal; margin:0; padding:0 5px; background:#d2ddea url(images/bg_gradient_x.png) repeat-x 0 -150px; }
 #latest-postings ul      { font-size:0.82em; list-style:none; margin:0; padding:0; }
 #latest-postings li      { margin:0; padding:0; line-height:1.5em; word-wrap:break-word; overflow:hidden; }
-#latest-postings li a    { font-size:0.82em; line-height:1.5em; text-decoration:none; display:block; margin:0; padding:3px 5px; }
+#latest-postings li a    { background-color: #f0f0f0; line-height:1.5em; text-decoration:none; display:block; margin:0; padding:3px 5px; }
 #latest-postings li a:visited, #latest-postings li a.read
                          { background-color: #ffffff; }
 #latest-postings li a:visited .entry-title, #latest-postings li a.read .entry-title

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -85,7 +85,7 @@ input.small,select.small{font-family:verdana,arial,sans-serif;font-size:.82em}
 #latest-postings h3{font-size:.69em;line-height:1.7em;font-weight:400;margin:0;padding:0 5px;background:#d2ddea url(images/bg_gradient_x.png) repeat-x 0 -150px}
 #latest-postings ul{font-size:.82em;list-style:none;margin:0;padding:0}
 #latest-postings li{margin:0;padding:0;line-height:1.5em;word-wrap:break-word;overflow:hidden}
-#latest-postings li a{line-height:1.5em;text-decoration:none;display:block;margin:0;padding:3px 5px}
+#latest-postings li a{background-color:#f0f0f0;line-height:1.5em;text-decoration:none;display:block;margin:0;padding:3px 5px}
 #latest-postings li a:visited,#latest-postings li a.read{background-color:#fff}
 #latest-postings li a:visited .entry-title,#latest-postings li a.read .entry-title{color:#007}
 #latest-postings li a:focus,#latest-postings li a:hover{background:#efefef;text-decoration:none}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -85,11 +85,12 @@ input.small,select.small{font-family:verdana,arial,sans-serif;font-size:.82em}
 #latest-postings h3{font-size:.69em;line-height:1.7em;font-weight:400;margin:0;padding:0 5px;background:#d2ddea url(images/bg_gradient_x.png) repeat-x 0 -150px}
 #latest-postings ul{font-size:.82em;list-style:none;margin:0;padding:0}
 #latest-postings li{margin:0;padding:0;line-height:1.5em;word-wrap:break-word;overflow:hidden}
-#latest-postings li a{font-size:.82em;line-height:1.5em;color:gray;text-decoration:none;display:block;margin:0;padding:3px 5px}
-#latest-postings li a:hover{background:#efefef;text-decoration:none}
-#latest-postings li a span{font-size:1.2em;line-height:1.5em;color:#00c}
-#latest-postings li a:visited span{color:#000077;}
-#latest-postings li a:focus span, #latest-postings li a:hover span{text-decoration:underline;}
+#latest-postings li a{line-height:1.5em;text-decoration:none;display:block;margin:0;padding:3px 5px}
+#latest-postings li a:visited,#latest-postings li a.read{background-color:#fff}
+#latest-postings li a:visited .entry-title,#latest-postings li a.read .entry-title{color:#007}
+#latest-postings li a:focus,#latest-postings li a:hover{background:#efefef;text-decoration:none}
+#latest-postings li a:focus .entry-title,#latest-postings li a:hover .entry-title{text-decoration:underline}
+#latest-postings li a .entry-date,#latest-postings li a.read .entry-date{font-size:.82em;color:gray}
 #tagcloud{position:relative;margin:0 0 20px 20px;background:#f9f9f9;border:1px solid #bacbdf;padding:0;width:13em}
 #tagcloud p{margin:0;padding:5px;font-size:.69em;line-height:1.5em}
 #tagcloud a.hide-sidebar{position:absolute;top:2px;right:4px;margin:0;padding:0;line-height:11px}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -75,15 +75,15 @@ input.small,select.small{font-family:verdana,arial,sans-serif;font-size:.82em}
 #footermenu li:first-child a {padding-left:15px;}
 #pbmlf{clear:both;margin:0;padding:0 20px 11px;text-align:center;font-size:.69em;color:gray}
 #pbmlf a{color:gray;text-decoration:none}
-#sidebar{position:relative;float:right;margin:0;padding:0}
+#sidebar{position:relative;width:13em;float:right;margin:0;padding:0}
 #sidebar div{position:relative;z-index:2}
 #sidebar h3.sidebar{position:absolute;top:0;right:0;font-size:.69em;line-height:1.7em;font-weight:400;margin:0;padding:0 17px 0 5px;background:#d2ddea url(images/bg_gradient_x.png) repeat-x 0 -150px;border:1px solid #bacbdf;z-index:1}
 #sidebar h3.sidebar a{color:#000;text-decoration:none;z-index:2}
 #sidebartoggle{position:absolute;top:5px;right:4px;margin:0;padding:0;z-index:3}
-#latest-postings{position:relative;margin:0 0 20px 20px;background:#f9f9f9;border:1px solid #bacbdf;padding:0;width:13em}
+#latest-postings{position:relative;margin:0 0 20px 0;background:#f9f9f9;border:1px solid #bacbdf;padding:0}
 #latest-postings a.hide-sidebar{position:absolute;top:2px;right:4px;margin:0;padding:0;line-height:11px}
 #latest-postings h3{font-size:.69em;line-height:1.7em;font-weight:400;margin:0;padding:0 5px;background:#d2ddea url(images/bg_gradient_x.png) repeat-x 0 -150px}
-#latest-postings ul{font-size:.82em;list-style:none;margin:0;padding:0}
+#latest-postings ul{max-width:100%;font-size:.82em;list-style:none;margin:0;padding:0}
 #latest-postings li{margin:0;padding:0;line-height:1.5em;word-wrap:break-word;overflow:hidden}
 #latest-postings li a{background-color:#f0f0f0;line-height:1.5em;text-decoration:none;display:block;margin:0;padding:3px 5px}
 #latest-postings li a:visited,#latest-postings li a.read{background-color:#fff}
@@ -91,12 +91,12 @@ input.small,select.small{font-family:verdana,arial,sans-serif;font-size:.82em}
 #latest-postings li a:focus,#latest-postings li a:hover{background:#efefef;text-decoration:none}
 #latest-postings li a:focus .entry-title,#latest-postings li a:hover .entry-title{text-decoration:underline}
 #latest-postings li a .entry-date,#latest-postings li a.read .entry-date{font-size:.82em;color:gray}
-#tagcloud{position:relative;margin:0 0 20px 20px;background:#f9f9f9;border:1px solid #bacbdf;padding:0;width:13em}
+#tagcloud{position:relative;margin:0 0 20px 0;background:#f9f9f9;border:1px solid #bacbdf;padding:0}
 #tagcloud p{margin:0;padding:5px;font-size:.69em;line-height:1.5em}
 #tagcloud a.hide-sidebar{position:absolute;top:2px;right:4px;margin:0;padding:0;line-height:11px}
 #tagcloud h3{font-size:.69em;line-height:1.7em;font-weight:400;margin:0;padding:0 5px;background:#d2ddea url(images/bg_gradient_x.png) repeat-x 0 -150px}
 #tagcloud strong{font-weight:700;font-size:1.051em}
-#modmenu{position:relative;margin:0 0 20px 20px;background:#f9f9f9;border:1px solid #bacbdf;width:13em}
+#modmenu{position:relative;margin:0 0 20px 0;background:#f9f9f9;border:1px solid #bacbdf}
 #modmenu h3{font-size:.69em;line-height:1.7em;font-weight:400;margin:0;padding:0 5px;background:#d2ddea url(images/bg_gradient_x.png) repeat-x 0 -150px}
 #mod-options{list-style:none;margin:0;padding:5px;font-size:.69em!important;line-height:1.7em!important}
 #mod-options a {padding-left:15px;}

--- a/themes/default/subtemplates/index.inc.tpl
+++ b/themes/default/subtemplates/index.inc.tpl
@@ -7,8 +7,8 @@
 <div id="latest-postings">
 <h3>{#latest_postings_hl#}</h3>
 <ul id="latest-postings-container">
-{foreach from=$latest_postings item=posting}<li><a href="index.php?id={$posting.id}" title="{$posting.name}, {$posting.formated_time}{if $posting.category_name} ({$posting.category_name}){/if}"><span{if $posting.is_read} class="read"{/if}>{if $posting.pid==0}<strong>{$posting.subject}</strong>{else}{$posting.subject}{/if}</span><br />
-{if $posting.ago.days>1}{#posting_several_days_ago#|replace:"[days]":$posting.ago.days_rounded}{else}{if $posting.ago.days==0 && $posting.ago.hours==0}{#posting_minutes_ago#|replace:"[minutes]":$posting.ago.minutes}{elseif $posting.ago.days==0 && $posting.ago.hours!=0}{#posting_hours_ago#|replace:"[hours]":$posting.ago.hours|replace:"[minutes]":$posting.ago.minutes}{else}{#posting_one_day_ago#|replace:"[hours]":$posting.ago.hours|replace:"[minutes]":$posting.ago.minutes}{/if}{/if}</a></li>{/foreach}
+{foreach from=$latest_postings item=posting}<li><a href="index.php?id={$posting.id}" title="{$posting.name}, {$posting.formated_time}{if $posting.category_name} ({$posting.category_name}){/if}"{if $posting.is_read} class="read"{/if}><span class="entry-title">{if $posting.pid==0}<strong>{$posting.subject}</strong>{else}{$posting.subject}{/if}</span><br />
+<span class="entry-date">{if $posting.ago.days>1}{#posting_several_days_ago#|replace:"[days]":$posting.ago.days_rounded}{else}{if $posting.ago.days==0 && $posting.ago.hours==0}{#posting_minutes_ago#|replace:"[minutes]":$posting.ago.minutes}{elseif $posting.ago.days==0 && $posting.ago.hours!=0}{#posting_hours_ago#|replace:"[hours]":$posting.ago.hours|replace:"[minutes]":$posting.ago.minutes}{else}{#posting_one_day_ago#|replace:"[hours]":$posting.ago.hours|replace:"[minutes]":$posting.ago.minutes}{/if}{/if}</span></a></li>{/foreach}
 </ul>
 </div>
 {/if}

--- a/themes/default/subtemplates/index_table.inc.tpl
+++ b/themes/default/subtemplates/index_table.inc.tpl
@@ -49,7 +49,7 @@
 <h3 class="sidebar"><a href="index.php?toggle_sidebar=true" title="{#toggle_sidebar#}">{#sidebar#}</a></h3>
 <div id="sidebarcontent">
 {if $latest_postings}
-<div>
+<div id="latest-postings">
 <h3>{#latest_postings_hl#}</h3>
 <ul id="latest-postings-container">
 {foreach from=$latest_postings item=posting}<li><a{if $posting.is_read} class="read"{/if} href="index.php?mode=thread&amp;id={$posting.tid}{if $posting.pid!=0}#p{$posting.id}{/if}" title="{$posting.name}, {$posting.formated_time} {if $posting.category_name}({$posting.category_name}){/if}"><span class="entry-title">{if $posting.pid==0}<strong>{$posting.subject}</strong>{else}{$posting.subject}{/if}</span><br /><span class="entry-date">{if $posting.ago.days>1}{#posting_several_days_ago#|replace:"[days]":$posting.ago.days_rounded}{else}{if $posting.ago.days==0 && $posting.ago.hours==0}{#posting_minutes_ago#|replace:"[minutes]":$posting.ago.minutes}{elseif $posting.ago.days==0 && $posting.ago.hours!=0}{#posting_hours_ago#|replace:"[hours]":$posting.ago.hours|replace:"[minutes]":$posting.ago.minutes}{else}{#posting_one_day_ago#|replace:"[hours]":$posting.ago.hours|replace:"[minutes]":$posting.ago.minutes}{/if}{/if}<span></a></li>{/foreach}
@@ -57,7 +57,7 @@
 </div>
 {/if}
 {if $tag_cloud}
-<div>
+<div id="tagcloud">
 <h3>{#tag_cloud_hl#}</h3>
 <p class="tagcloud">{foreach from=$tag_cloud item=tag}
 {section name=strong_start start=0 loop=$tag.frequency}<strong>{/section}<a href="index.php?mode=search&amp;search={$tag.escaped}&amp;method=tags">{$tag.tag}</a> {section name=strong_end start=0 loop=$tag.frequency}</strong>{/section}
@@ -65,7 +65,7 @@
 </div>
 {/if}
 {if $admin || $mod}
-<div>
+<div id="modmenu">
 	<h3>{#options#}</h3>
 	<ul id="mod-options">
 		{if $number_of_non_activated_users}<li><a href="index.php?mode=user" class="non-activated-users">{#non_activated_users_link#|replace:'[counter]':$number_of_non_activated_users}</a></li>{/if}

--- a/themes/default/subtemplates/index_table.inc.tpl
+++ b/themes/default/subtemplates/index_table.inc.tpl
@@ -51,8 +51,8 @@
 {if $latest_postings}
 <div>
 <h3>{#latest_postings_hl#}</h3>
-<ul class="latestposts">
-{foreach from=$latest_postings item=posting}<li><a{if $posting.is_read} class="read"{/if} href="index.php?mode=thread&amp;id={$posting.tid}{if $posting.pid!=0}#p{$posting.id}{/if}" title="{$posting.name}, {$posting.formated_time} {if $posting.category_name}({$posting.category_name}){/if}">{if $posting.pid==0}<strong>{$posting.subject}</strong>{else}{$posting.subject}{/if}</a><br />{if $posting.ago.days>1}{#posting_several_days_ago#|replace:"[days]":$posting.ago.days_rounded}{else}{if $posting.ago.days==0 && $posting.ago.hours==0}{#posting_minutes_ago#|replace:"[minutes]":$posting.ago.minutes}{elseif $posting.ago.days==0 && $posting.ago.hours!=0}{#posting_hours_ago#|replace:"[hours]":$posting.ago.hours|replace:"[minutes]":$posting.ago.minutes}{else}{#posting_one_day_ago#|replace:"[hours]":$posting.ago.hours|replace:"[minutes]":$posting.ago.minutes}{/if}{/if}</li>{/foreach}
+<ul id="latest-postings-container">
+{foreach from=$latest_postings item=posting}<li><a{if $posting.is_read} class="read"{/if} href="index.php?mode=thread&amp;id={$posting.tid}{if $posting.pid!=0}#p{$posting.id}{/if}" title="{$posting.name}, {$posting.formated_time} {if $posting.category_name}({$posting.category_name}){/if}"><span class="entry-title">{if $posting.pid==0}<strong>{$posting.subject}</strong>{else}{$posting.subject}{/if}</span><br /><span class="entry-date">{if $posting.ago.days>1}{#posting_several_days_ago#|replace:"[days]":$posting.ago.days_rounded}{else}{if $posting.ago.days==0 && $posting.ago.hours==0}{#posting_minutes_ago#|replace:"[minutes]":$posting.ago.minutes}{elseif $posting.ago.days==0 && $posting.ago.hours!=0}{#posting_hours_ago#|replace:"[hours]":$posting.ago.hours|replace:"[minutes]":$posting.ago.minutes}{else}{#posting_one_day_ago#|replace:"[hours]":$posting.ago.hours|replace:"[minutes]":$posting.ago.minutes}{/if}{/if}<span></a></li>{/foreach}
 </ul>
 </div>
 {/if}


### PR DESCRIPTION
To make it easier to share the CSS-rulesets for the list of latest postings for registered and unregistered users, the class `read` was tied to the link itself instead to the `span` that contains the subject of the entry. On that way links with the class `read` and with the pseudo class `:visited` can share the same rules. Before this was impossible because of class `read` was tied to a span within the link.

Additionally the blocks in `#bottombar` got the same ids as the corresponding blocks in `#sidebar`. To achieve this, a few rules was re-tied to parent elements and corrections ws made.
