### PR TITLE
correct label

### DIFF
--- a/includes/admin.inc.php
+++ b/includes/admin.inc.php
@@ -879,11 +879,13 @@ if (isset($_SESSION[$settings['session_prefix'].'user_id']) && isset($_SESSION[$
 			if (($ar_pw == "" or $ar_pw_conf == "") && !isset($ar_send_userdata)) $errors[] = 'error_send_userdata';
 
 			if (my_strlen($ar_username, $lang['charset']) > $settings['name_maxlength'])
-			$errors[] = $lang['name_marking'] . " " .$lang['error_input_too_long'];
+				$errors[] = $lang['name_marking'] . " " .$lang['error_username_too_long'];
 
 			$too_long_word = too_long_word($ar_username, $settings['name_word_maxlength']);
-			if ($too_long_word) $errors[] = 'error_word_too_long';
-			if ($ar_pw_conf != $ar_pw) $errors[] = 'error_pw_conf_uneven';
+			if ($too_long_word)
+				$errors[] = 'error_word_too_long';
+			if ($ar_pw_conf != $ar_pw) 
+				$errors[] = 'error_pw_conf_uneven';
 		}
 		// save user if no errors:
 		if (empty($errors)) {


### PR DESCRIPTION
- change not defined $lang['error_input_too_long'] to
$lang['error_username_too_long']