### PR TITLE
Fix: set the URL of the interim project page because …

### DIFF
--- a/themes/default/main.tpl
+++ b/themes/default/main.tpl
@@ -87,7 +87,7 @@
 Please donate if you want to remove this link:
 https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=1922497
 *}
-<div id="pbmlf"><a href="http://mylittleforum.net/">powered by my little forum</a></div>
+<div id="pbmlf"><a href="https://projekt-mlf.de/">powered by my little forum</a></div>
 
 <!--[if IE]></div><![endif]-->
 


### PR DESCRIPTION
… the original page is not accessible at the moment. The URL will be replaced with the original one, when the original site will be accessible again.