### PR TITLE
Fix: corrected the path to the CSS-files in the file list for version 2.4.7

### DIFF
--- a/update/update_2.3.5-2.4.php
+++ b/update/update_2.3.5-2.4.php
@@ -128,8 +128,8 @@ switch($settings['version']) {
 		$update['items'][] = 'themes/default/subtemplates/register.inc.tpl';         // #287, #305
 		$update['items'][] = 'themes/default/subtemplates/posting.inc.tpl';          // #287, #303, #305
 		$update['items'][] = 'themes/default/subtemplates/subnavigation_2.inc.tpl';  // #291, #294, #295
-		$update['items'][] = 'themes/style.css';                                     // #303, #305
-		$update['items'][] = 'themes/style.min.css';                                 // #303, #305
+		$update['items'][] = 'themes/default/style.css';                             // #303, #305
+		$update['items'][] = 'themes/default/style.min.css';                         // #303, #305
 		$update['items'][] = 'includes/admin.inc.php';                               // #304, #321
 		$update['items'][] = 'includes/bookmark.inc.php';                            // #287, #297
 		$update['items'][] = 'includes/entry.inc.php';                               // #297


### PR DESCRIPTION
This is important for updates from older versions as long as the CSS-files will not get actualisations during future updates.