### PR TITLE
Change: removed the workaround for turkish language

### DIFF
--- a/lang/turkish.lang
+++ b/lang/turkish.lang
@@ -11,10 +11,6 @@ charset =                         utf-8
 #locale =                         tr_TR.utf8
 #locale =                         tr_TR
 #locale =                         tr
-# Caution: setting Turkish locale can cause problems --> http://bugs.php.net/39993
-locale =                          en_US.utf8
-locale =                          en_US
-locale =                          en
 locale_charset =                  utf-8
 word_delimiters =                 ' '
 dir =                             ltr


### PR DESCRIPTION
Workaround was to use US-locales instead the turkish ones for a PHP-bug that was solved ages ago with PHP 5.2. See also #361.