### PR TITLE
Timespan for form completion

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2787,6 +2787,14 @@ function addBookmark($user_id, $posting_id) {
 	}
 }
 
+function setReceiptTimestamp($offset = 0) {
+	global $settings;
+	// SPAM protection (Time (difference) between page reload)
+	if (isset($_SESSION[$settings['session_prefix'] . 'receipt_timestamp']) && intval($_SESSION[$settings['session_prefix'] . 'receipt_timestamp']) > 0)
+		$_SESSION[$settings['session_prefix'] . 'receipt_timestamp_difference'] = $_SERVER['REQUEST_TIME'] + $offset - $_SESSION[$settings['session_prefix'] . 'receipt_timestamp'];
+	$_SESSION[$settings['session_prefix'] . 'receipt_timestamp'] = $_SERVER['REQUEST_TIME'];
+}
+
 /**
  * sends a status code, displays an error message and halts the script
  *

--- a/includes/posting.inc.php
+++ b/includes/posting.inc.php
@@ -1190,7 +1190,6 @@ switch ($action) {
 					$smarty->assign("data_privacy_agreement", true);
 				if (isset($data_privacy_agree))
 					$smarty->assign('data_privacy_statement_agree', intval($data_privacy_agree));
-				//$_SESSION[$settings['session_prefix'] . 'formtime'] = TIMESTAMP - 7; // 7 seconds credit (form already sent)
 				$smarty->assign('subtemplate', 'posting.inc.tpl');
 			}
 		}

--- a/includes/posting.inc.php
+++ b/includes/posting.inc.php
@@ -1011,8 +1011,7 @@ switch ($action) {
 					else
 						header('Location: index.php?id=' . $new_data['id']);
 					exit;
-				} 
-				elseif (isset($_POST['save_entry']) && $posting_mode == 1) {
+				} elseif (isset($_POST['save_entry']) && $posting_mode == 1) {
 					// save edited posting:
 					$tid_result = @mysqli_query($connid, "SELECT pid, tid, name, location, user_id, category, subject, text FROM " . $db_settings['forum_table'] . " WHERE id = " . intval($id)) or raise_error('database_error', mysqli_error($connid));
 					$field = mysqli_fetch_array($tid_result);

--- a/install/install.sql
+++ b/install/install.sql
@@ -140,6 +140,12 @@ INSERT INTO mlf2_settings VALUES ('data_privacy_agreement', '0');
 INSERT INTO mlf2_settings VALUES ('data_privacy_statement_url', '');
 INSERT INTO mlf2_settings VALUES ('bbcode_latex', '0');
 INSERT INTO mlf2_settings VALUES ('bbcode_latex_uri', 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_CHTML.js');
+INSERT INTO mlf2_settings VALUES ('min_posting_time', '5'); 
+INSERT INTO mlf2_settings VALUES ('min_register_time', '5');
+INSERT INTO mlf2_settings VALUES ('min_email_time', '5');
+INSERT INTO mlf2_settings VALUES ('max_posting_time', '10800'); 
+INSERT INTO mlf2_settings VALUES ('max_register_time', '10800');
+INSERT INTO mlf2_settings VALUES ('max_email_time', '10800');
 
 INSERT INTO mlf2_smilies VALUES (1, 1, 'smile.png', ':-)', '', '', '', '', '');
 INSERT INTO mlf2_smilies VALUES (2, 2, 'wink.png', ';-)', '', '', '', '', '');

--- a/update/update.sql
+++ b/update/update.sql
@@ -372,4 +372,5 @@ INSERT INTO mlf2_settings (`name`, `value`) VALUES ('uploads_per_page', '20');
 -- 2.4.9 to 2.5
 /*
 INSERT INTO `mlf2_settings` (`name`, `value`) VALUES ('bbcode_latex', '0'), ('bbcode_latex_uri', 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_CHTML.js');
+INSERT INTO `mlf2_settings` (`name`, `value`) VALUES ('min_posting_time', '5'), ('min_register_time', '5'), ('min_email_time', '5'), ('max_posting_time', '10800'), ('max_register_time', '10800'), ('max_email_time', '10800');
 */

--- a/update/update_2.4.8-2.5.php
+++ b/update/update_2.4.8-2.5.php
@@ -121,6 +121,9 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.8', '2
 	if(!@mysqli_query($connid, "DELETE FROM `".$db_settings['settings_table']."` WHERE name = 'flash_default_height';")) {
 		$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 	}
+	if(!@mysqli_query($connid, "INSERT INTO `".$db_settings['settings_table']."` (`name`, `value`) VALUES ('min_posting_time', '5'), ('min_register_time', '5'), ('min_email_time', '5'),  ('max_posting_time', '10800'), ('max_register_time', '10800'), ('max_email_time', '10800');")) {
+		$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+	}
 }
 
 if(empty($update['errors'])) {


### PR DESCRIPTION
- observe timespan for form completion and show an error, if the timespan is below a suitable threshold
- remove hard coded thresholds
- add new database entries for tuning threshold values
- default values: min = 5 sec and max = 10800 sec
- remove "credit time" for incomplete filled forms
- no distinction of user type
- see https://github.com/ilosuna/mylittleforum/issues/406