### PR TITLE
LC_NUMERIC

### DIFF
--- a/index.php
+++ b/index.php
@@ -59,6 +59,7 @@ if ($lang['locale_charset'] != $lang['charset'])
     define('LOCALE_CHARSET', $lang['locale_charset']);
 @ini_set('default_charset', $lang['charset']);
 setlocale(LC_ALL, $lang['locale']);
+setlocale(LC_NUMERIC, "C");
 
 $smarty->assign('settings', $settings);
 


### PR DESCRIPTION
- added `setlocale(LC_NUMERIC, "C");` to handle the decimal separator (in case of content switching)
- https://github.com/ilosuna/mylittleforum/issues/428