### PR TITLE
Fix: thumbnails was elongated to the complete height of the entry

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -626,7 +626,7 @@ a.reply-search:visited   { /*color:#800080;*/ }
 a.thread-search:active,
 a.reply-search:active    { color:#ff0000; }
 
-img.thumbnail            { width:150px; border:1px solid #c0c0c0; margin: 0; }
+img.thumbnail            { width:150px; border:1px solid #c0c0c0; margin: 0; height:auto; }
 a:link img.thumbnail     { color: #0000ff; border:1px solid #c0c0c0; }
 a:visited img.thumbnail  { color: #0000ff; border:1px solid #c0c0c0; }
 a:hover img.thumbnail    { color: #0000ff; border:1px solid #000000; }

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -414,7 +414,7 @@ ul.searchresults li li{font-size:1em}
 a.thread-search{padding-left:18px;color:#00c;font-weight:700;background:url(images/bg_sprite_1.png) no-repeat 0 -148px}
 a.reply-search{padding-left:18px;color:#00c;font-weight:700;background:url(images/bg_sprite_1.png) no-repeat 0 -448px}
 a.thread-search:active,a.reply-search:active{color:red}
-img.thumbnail{width:150px;border:1px solid silver;margin:0}
+img.thumbnail{width:150px;border:1px solid silver;margin:0;height:auto}
 a:link img.thumbnail{color:#00f;border:1px solid silver}
 a:visited img.thumbnail{color:#00f;border:1px solid silver}
 a:hover img.thumbnail{color:#00f;border:1px solid #000}


### PR DESCRIPTION
With `height: auto;` for `img.thumbnail` the height is set by the browser to the value that respects the image ratio in relation to the given width of (currently) `150px`.