### PR TITLE
Bugfixes for version 2.4.19

### DIFF
--- a/includes/admin.inc.php
+++ b/includes/admin.inc.php
@@ -1240,8 +1240,8 @@ if (isset($_SESSION[$settings['session_prefix'].'user_id']) && isset($_SESSION[$
 			$smarty->assign('breadcrumbs',$breadcrumbs);
 			$smarty->assign('subnav_location','subnav_settings');
 			if (isset($_GET['saved'])) $smarty->assign('saved', true);
-			$rGetSettingsEdit = mysqli_fetch_all(mysqli_query($connid, "SELECT name, value FROM " . $db_settings['settings_table']), MYSQLI_ASSOC);
-			foreach ($rGetSettingsEdit as $line) {
+			$rGetSettingsEdit = mysqli_query($connid, "SELECT name, value FROM " . $db_settings['settings_table']);
+			while ($line = mysqli_fetch_assoc($rGetSettingsEdit)) {
 				$settings_array[$line['name']] = $line['value'];
 			}
 			$smarty->assign('edSet', $settings_array);
@@ -1269,8 +1269,8 @@ if (isset($_SESSION[$settings['session_prefix'].'user_id']) && isset($_SESSION[$
 			$smarty->assign('breadcrumbs', $breadcrumbs);
 			$smarty->assign('subnav_location', 'subnav_advanced_settings');
 			if (isset($_GET['saved'])) $smarty->assign('saved', true);
-			$rGetSettingsEdit = mysqli_fetch_all(mysqli_query($connid, "SELECT name, value FROM " . $db_settings['settings_table'] ." ORDER BY name ASC"), MYSQLI_ASSOC);
-			foreach ($rGetSettingsEdit as $line) {
+			$rGetSettingsEdit = mysqli_query($connid, "SELECT name, value FROM " . $db_settings['settings_table'] ." ORDER BY name ASC");
+			while ($line = mysqli_fetch_assoc($rGetSettingsEdit)) {
 				$settings_array[$line['name']] = $line['value'];
 			}
 			$i=0;

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -89,8 +89,7 @@ function daily_actions($current_time=0) {
 	$nda = mysqli_fetch_assoc($rNDA);
 	if($current_time==0)
 		$current_time = TIMESTAMP;
-	#if($current_time > $next_daily_actions['value']) {
-	if ($current_time > intval($nda[0]['value'])) {
+	if ($current_time > intval($nda['value'])) {
 		// clear up expired auto_login_codes:
 		if($settings['autologin'] == 1) {
 			@mysqli_query($connid, "UPDATE ".$db_settings['userdata_table']." SET auto_login_code='' WHERE auto_login_code != '' AND last_login < (NOW() - INTERVAL ".$settings['cookie_validity_days']." DAY)");


### PR DESCRIPTION
- Use of `mysqli_fetch_all` is not safe because some PHP installations doesn't know this function. Use `mysqli_fetch_assoc` in a loop instead.
- When fetching only one line of a database request (`SELECT`), `mysqli_fetch_assoc` returns a flat array (`$foo` instead `$foo[0]` for the first row)