### PR TITLE
fix collation of wordlist table

### DIFF
--- a/install/install.sql
+++ b/install/install.sql
@@ -20,7 +20,7 @@ CREATE TABLE mlf2_tags (`id` int(11) NOT NULL AUTO_INCREMENT, `tag` varchar(255)
 CREATE TABLE mlf2_subscriptions (`user_id` int(12) UNSIGNED NULL, `eid` int(12) UNSIGNED NOT NULL, `unsubscribe_code` varchar(36) NOT NULL, `tstamp` datetime DEFAULT NULL, UNIQUE `user_thread` (`user_id`, `eid`) USING HASH, INDEX `hash` (`unsubscribe_code`)) ENGINE = InnoDB CHARSET=utf8;
 CREATE TABLE mlf2_b8_rating (`eid` int(11) NOT NULL, `spam` tinyint(1) NOT NULL DEFAULT '0', `training_type` tinyint(1) NOT NULL DEFAULT '0', PRIMARY KEY (`eid`), KEY `b8_spam` (`spam`), KEY training_type (training_type)) CHARSET=utf8 COLLATE=utf8_general_ci;
 CREATE TABLE mlf2_akismet_rating (`eid` int(11) NOT NULL, `spam` tinyint(1) NOT NULL DEFAULT '0', `spam_check_status` tinyint(1) NOT NULL DEFAULT '0', PRIMARY KEY (`eid`), KEY `akismet_spam` (`spam`), KEY spam_check_status (spam_check_status)) CHARSET=utf8 COLLATE=utf8_general_ci;
-CREATE TABLE mlf2_b8_wordlist (`token` varchar(255) character set utf8mb4 collate utf8mb4_bin NOT NULL, `count_ham` int unsigned default NULL, `count_spam` int unsigned default NULL, PRIMARY KEY (`token`)) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+CREATE TABLE mlf2_b8_wordlist (`token` varchar(255) NOT NULL, `count_ham` int unsigned default NULL, `count_spam` int unsigned default NULL, PRIMARY KEY (`token`)) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 CREATE TABLE mlf2_uploads (`id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT, `uploader` int(10) UNSIGNED NULL, `filename` varchar(64) NULL, `tstamp` datetime NULL, PRIMARY KEY (id)) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 INSERT INTO mlf2_banlists VALUES ('user_agents', '');

--- a/install/install.sql
+++ b/install/install.sql
@@ -20,7 +20,7 @@ CREATE TABLE mlf2_tags (`id` int(11) NOT NULL AUTO_INCREMENT, `tag` varchar(255)
 CREATE TABLE mlf2_subscriptions (`user_id` int(12) UNSIGNED NULL, `eid` int(12) UNSIGNED NOT NULL, `unsubscribe_code` varchar(36) NOT NULL, `tstamp` datetime DEFAULT NULL, UNIQUE `user_thread` (`user_id`, `eid`) USING HASH, INDEX `hash` (`unsubscribe_code`)) ENGINE = InnoDB CHARSET=utf8;
 CREATE TABLE mlf2_b8_rating (`eid` int(11) NOT NULL, `spam` tinyint(1) NOT NULL DEFAULT '0', `training_type` tinyint(1) NOT NULL DEFAULT '0', PRIMARY KEY (`eid`), KEY `b8_spam` (`spam`), KEY training_type (training_type)) CHARSET=utf8 COLLATE=utf8_general_ci;
 CREATE TABLE mlf2_akismet_rating (`eid` int(11) NOT NULL, `spam` tinyint(1) NOT NULL DEFAULT '0', `spam_check_status` tinyint(1) NOT NULL DEFAULT '0', PRIMARY KEY (`eid`), KEY `akismet_spam` (`spam`), KEY spam_check_status (spam_check_status)) CHARSET=utf8 COLLATE=utf8_general_ci;
-CREATE TABLE mlf2_b8_wordlist (`token` varchar(255) character set utf8mb4 collate utf8_bin NOT NULL, `count_ham` int unsigned default NULL, `count_spam` int unsigned default NULL, PRIMARY KEY (`token`)) CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+CREATE TABLE mlf2_b8_wordlist (`token` varchar(255) character set utf8mb4 collate utf8mb4_bin NOT NULL, `count_ham` int unsigned default NULL, `count_spam` int unsigned default NULL, PRIMARY KEY (`token`)) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 CREATE TABLE mlf2_uploads (`id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT, `uploader` int(10) UNSIGNED NULL, `filename` varchar(64) NULL, `tstamp` datetime NULL, PRIMARY KEY (id)) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 INSERT INTO mlf2_banlists VALUES ('user_agents', '');


### PR DESCRIPTION
When fixing the collation for `mlf2_b8_wordlist`, we also need to change the storage engine of this table.

UTF-8 is a variable encoding, having 1 to 4 bytes encoding a single character. Assuming that every character of the `token` field is a 4 byte char, the primary key would be larger than 1000 bytes which is the maximum key length for MyISAM tables.

closes #482 