### PR TITLE
new users (created by admin)

### DIFF
--- a/includes/admin.inc.php
+++ b/includes/admin.inc.php
@@ -872,8 +872,8 @@ if (isset($_SESSION[$settings['session_prefix'].'user_id']) && isset($_SESSION[$
 			if ($ar_pw == "" && !isset($ar_send_userdata)) 
 				$errors[] = 'error_send_userdata';
 
-			if (my_strlen($ar_username, $lang['charset']) > $settings['name_maxlength'])
-				$errors[] = $lang['name_marking'] . " " .$lang['error_username_too_long'];
+			if (my_strlen($ar_username, $lang['charset']) > $settings['username_maxlength'])
+				$errors[] = 'error_name_too_long';
 
 			$too_long_word = too_long_word($ar_username, $settings['name_word_maxlength']);
 			if ($too_long_word)

--- a/themes/default/subtemplates/admin.inc.tpl
+++ b/themes/default/subtemplates/admin.inc.tpl
@@ -637,7 +637,7 @@
 <ul>
 {section name=mysec loop=$errors}
 {assign var="error" value=$errors[mysec]}
-<li>{$smarty.config.$error}</li>
+<li>{$smarty.config.$error|replace:"[word]":$ar_username}</li>
 {/section}
 </ul>
 {/if}


### PR DESCRIPTION
- corrected error message if the length of the user name is invalid
- corrected setting variable used in if-condition that checks the length (`$settings['username_maxlength']` instead of `$settings['name_maxlength']`, which is used for the real name of the user)