### PR TITLE
auto delete spam

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -116,7 +116,7 @@ function daily_actions($current_time=0) {
 									`id` IN (SELECT `". $db_settings['akismet_rating_table'] ."`.`eid` 
 									FROM `". $db_settings['akismet_rating_table'] ."` 
 									JOIN `". $db_settings['b8_rating_table'] ."` ON `". $db_settings['akismet_rating_table'] ."`.`eid` = `". $db_settings['b8_rating_table'] ."`.`eid` 
-									WHERE `". $db_settings['akismet_rating_table'] ."`.`spam` = 1 AND `". $db_settings['b8_rating_table'] ."`.`spam` = 1); ");
+									WHERE `". $db_settings['akismet_rating_table'] ."`.`spam` = 1 OR `". $db_settings['b8_rating_table'] ."`.`spam` = 1); ");
 
 		// if possible, load new version info from Github
 		if (isset($settings) && isset($settings['version'])) {


### PR DESCRIPTION
- corrected SQL for auto delete spam
- spam is deleted if at least one service classified an entry as spam