### PR TITLE
Change: revert to regex for e-mail checking …

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -397,7 +397,7 @@ function is_valid_url($url)
  * @return bool
  */
 function is_valid_email($email) {
-	if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+	if (!preg_match("/^([\w\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([\w-]+\.)+))([a-zA-Z]{2,}|[0-9]{1,3})(\]?)$/", $email)) {
 		return false;
 	}
 	if (contains_invalid_string($email)) {


### PR DESCRIPTION
… with the PHP-7.3-compatible syntax.

The function filter_vars is not able to validate e-mail-addresses from Punycode-domains.