### PR TITLE
Fix for invalid HTML structure introduced in #530

### DIFF
--- a/themes/default/main.tpl
+++ b/themes/default/main.tpl
@@ -96,8 +96,12 @@
 {if $forum_time_zone}{#forum_time_with_time_zone#|replace:'[time]':$forum_time|replace:'[time_zone]':$forum_time_zone}{else}{#forum_time#|replace:'[time]':$forum_time}{/if}</div>
 <div id="footer-2">
 <ul id="footermenu">
-{if $settings.rss_feed==1}<li><li><a href="#top" class="go-to-top-link" title="{#back_to_top_link_title#}">{#back_to_top_link#}</a></li><a class="rss" href="index.php?mode=rss" title="{#rss_feed_postings_title#}">{#rss_feed_postings#}</a> &nbsp;<a class="rss" href="index.php?mode=rss&amp;items=thread_starts" title="{#rss_feed_new_threads_title#}">{#rss_feed_new_threads#}</a></li>{/if}<li><a href="index.php?mode=contact" title="{#contact_linktitle#}" rel="nofollow">{#contact_link#}</a></li>
-</ul></div>
+ <li><a href="#top" class="go-to-top-link" title="{#back_to_top_link_title#}">{#back_to_top_link#}</a></li>
+{if $settings.rss_feed==1} <li><a class="rss" href="index.php?mode=rss" title="{#rss_feed_postings_title#}">{#rss_feed_postings#}</a></li>
+ <li><a class="rss" href="index.php?mode=rss&amp;items=thread_starts" title="{#rss_feed_new_threads_title#}">{#rss_feed_new_threads#}</a></li>{/if}
+ <li><a href="index.php?mode=contact" title="{#contact_linktitle#}" rel="nofollow">{#contact_link#}</a></li>
+</ul>
+</div>
 </div>
 
 {*

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -81,7 +81,7 @@ img.show-sidebar         { background:url(images/bg_sprite_2.png) no-repeat 0 -2
 #subnavmenu a.hierarchic { padding-left:13px; background:url(images/bg_sprite_1.png) no-repeat 0 -948px; }
 #subnavmenu a.fold-postings
                          { padding-left:13px; background:url(images/bg_sprite_1.png) no-repeat 0 -998px; }
-a.rss                    { padding-left:13px; background:url(images/bg_sprite_1.png) no-repeat 0 -1048px; }
+a.rss                    { background:url(images/bg_sprite_1.png) no-repeat 3px -1048px; }
 
 input.small,
 select.small             { font-family:verdana,arial,sans-serif; font-size:0.82em; }
@@ -106,7 +106,7 @@ select.small             { font-family:verdana,arial,sans-serif; font-size:0.82e
 #footermenu li:first-child:before
                          { content:""; }
 #footermenu li a         { padding-left:5px; }
-#footermenu li:first-child a 
+#footermenu li:first-child a, #footermenu li a.rss
                          { padding-left:15px; }
 #footermenu a.go-to-top-link
                          { padding-left: 16px; background: url(images/arrow_up.png) no-repeat 0 0 / auto 90%; }

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -68,11 +68,11 @@ input.small,select.small{font-family:verdana,arial,sans-serif;font-size:.82em}
 #footer #footer-1{margin:0;padding:7px 0 10px 20px;float:left}
 #footer #footer-2{margin:0;padding:7px 20px 10px 0;text-align:right}
 #footermenu{margin:0 0 1em;list-style-type:none}
-#footermenu li{display:inline;margin-left:5px;padding-left:0px;}
-#footermenu li:first-child{margin-left:0;padding-left:0px;}
-#footermenu li:before{content:"|";}
-#footermenu li:first-child:before{content:"";}
-#footermenu li a {padding-left:5px;}
+#footermenu li{display:inline;margin-left:5px;padding-left:0px}
+#footermenu li:first-child{margin-left:0;padding-left:0px}
+#footermenu li:before{content:"|"}
+#footermenu li:first-child:before{content:""}
+#footermenu li a{padding-left:5px}
 #footermenu li:first-child a,#footermenu li a.rss{padding-left:15px}
 #footermenu a.go-to-top-link{padding-left:16px;background:url(images/arrow_up.png) no-repeat 0 0 / auto 90%}
 #pbmlf{clear:both;margin:0;padding:0 20px 11px;text-align:center;font-size:.69em;color:gray}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -57,7 +57,7 @@ img.show-sidebar{background:url(images/bg_sprite_2.png) no-repeat 0 -22px}
 #subnavmenu a.linear{padding-left:13px;background:url(images/bg_sprite_1.png) no-repeat 0 -898px}
 #subnavmenu a.hierarchic{padding-left:13px;background:url(images/bg_sprite_1.png) no-repeat 0 -948px}
 #subnavmenu a.fold-postings{padding-left:13px;background:url(images/bg_sprite_1.png) no-repeat 0 -998px}
-a.rss{padding-left:13px;background:url(images/bg_sprite_1.png) no-repeat 0 -1048px}
+a.rss{background:url(images/bg_sprite_1.png) no-repeat 3px -1048px}
 input.small,select.small{font-family:verdana,arial,sans-serif;font-size:.82em}
 #content{margin:0;padding:20px;min-height:200px;background:#fff}
 #content p,#content ul,#content td{font-size:.82em;line-height:1.5em;max-width:60em}
@@ -73,7 +73,7 @@ input.small,select.small{font-family:verdana,arial,sans-serif;font-size:.82em}
 #footermenu li:before{content:"|";}
 #footermenu li:first-child:before{content:"";}
 #footermenu li a {padding-left:5px;}
-#footermenu li:first-child a {padding-left:15px;}
+#footermenu li:first-child a,#footermenu li a.rss{padding-left:15px}
 #footermenu a.go-to-top-link{padding-left:16px;background:url(images/arrow_up.png) no-repeat 0 0 / auto 90%}
 #pbmlf{clear:both;margin:0;padding:0 20px 11px;text-align:center;font-size:.69em;color:gray}
 #pbmlf a{color:gray;text-decoration:none}


### PR DESCRIPTION
With the back-to-top-link, introduced in #530, I added an invalid HTML structure for the link, provided in the page footer. Additionally the link was be shown only, when RSS is activated.

Now the link in the footer shows up in every case on every site. The links, inserted in the options lists, connected to every entry, was not affected by the bug.