### PR TITLE
Add field user_type to the thread tree below a single entry

### DIFF
--- a/includes/entry.inc.php
+++ b/includes/entry.inc.php
@@ -138,7 +138,7 @@
 	if ($entrydata['spam'] == 1 && isset($id))
 		$display_spam_query_and .= " OR `ft`.`id` = " . intval($id);
 	$result = mysqli_query($connid, "SELECT id, pid, tid, ft.user_id, UNIX_TIMESTAMP(ft.time) AS time, UNIX_TIMESTAMP(ft.time + INTERVAL " . $time_difference . " MINUTE) AS disp_time,
-                        UNIX_TIMESTAMP(last_reply) AS last_reply, name, user_name, subject, category, marked, text, rst.user_id AS req_user,
+                        UNIX_TIMESTAMP(last_reply) AS last_reply, name, user_name, user_type, subject, category, marked, text, rst.user_id AS req_user,
 						" . $db_settings['akismet_rating_table'] . ".spam AS akismet_spam,
 						" . $db_settings['b8_rating_table'] . ".spam AS b8_spam					
 						FROM " . $db_settings['forum_table'] . " AS ft

--- a/themes/default/subtemplates/entry.inc.tpl
+++ b/themes/default/subtemplates/entry.inc.tpl
@@ -73,7 +73,11 @@
 {function name=tree level=0}
 <li>{if $data.$element.id!=$id}<a class="{if $data.$element.pid==0&&$data.$element.new}threadnew{elseif $data.$element.pid==0}thread{elseif $data.$element.pid!=0&&$data.$element.new}replynew{else}reply{/if}{if $data.$element.is_read} read{/if}" href="index.php?id={$data.$element.id}">{$data.$element.subject}</a>{else}<span class="{if $data.$element.pid==0}{if $data.$element.new}currentthreadnew{else}currentthread{/if}{else}{if $data.$element.new}currentreplynew{else}currentreply{/if}{/if}">{$data.$element.subject}</span>{/if}{if $data.$element.no_text} <img class="no-text" src="{$THEMES_DIR}/{$theme}/images/no_text.png" title="{#no_text_title#}" alt="[ {#no_text_alt#} ]" width="11" height="9" />{/if} - 
 
-{if $data.$element.user_id>0}
+{if $data.$element.user_type==2}
+<strong class="admin registered_user">{$data.$element.name}</strong>, 
+{elseif $data.$element.user_type==1}
+<strong class="mod registered_user">{$data.$element.name}</strong>, 
+{elseif $data.$element.user_id>0}
 <strong class="registered_user">{$data.$element.name}</strong>, 
 {else}
 <strong>{$data.$element.name}</strong>, 


### PR DESCRIPTION
Add the information and classes to the user name elements to make them behave like thread trees in the main views. That makes styling of the user names working in every occurence of displaying a thread tree.

Fixes #535