### PR TITLE
Unify HTML-structure for RSS links in the entry views

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -202,7 +202,7 @@ blockquote code          { font-family:"courier new",courier; color:#6f6f6f; }
 .posting-footer a.edit   { padding-left:16px; background:url(images/bg_sprite_3.png) no-repeat 0 2px; }
 .posting-footer a.delete { padding-left:13px; background:url(images/bg_sprite_3.png) no-repeat 0 -47px; }
 .posting-footer a.go-to-top-link
-						 { padding-left: 16px; background: url(images/arrow_up.png) no-repeat 0 0 / auto 90%; text-transform: lowercase; }
+						 { padding-left: 16px; background: url(images/arrow_up.png) no-repeat 0 0 / auto 90%; }
 .posting-footer a.add-bookmark
 						 { padding-left:14px; background:url(images/bg_sprite_3.png) no-repeat 0 -97px; }
 .posting-footer a.delete-bookmark

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -82,8 +82,7 @@ img.show-sidebar         { background:url(images/bg_sprite_2.png) no-repeat 0 -2
 #subnavmenu a.fold-postings
                          { padding-left:13px; background:url(images/bg_sprite_1.png) no-repeat 0 -998px; }
 a.rss                    { background:url(images/bg_sprite_1.png) no-repeat 3px -1048px; }
-p.right a.rss, 
-div.small a.rss          { padding-left:15px; }
+p.right a.rss,           { padding-left:15px; }
 
 input.small,
 select.small             { font-family:verdana,arial,sans-serif; font-size:0.82em; }

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -146,7 +146,7 @@ blockquote code{font-family:"courier new",courier;color:#6f6f6f}
 .posting-footer .options li{display:inline;margin:0 0 0 1em}
 .posting-footer a.edit{padding-left:16px;background:url(images/bg_sprite_3.png) no-repeat 0 2px}
 .posting-footer a.delete{padding-left:13px;background:url(images/bg_sprite_3.png) no-repeat 0 -47px}
-.posting-footer a.go-to-top-link{ padding-left:16px;background:url(images/arrow_up.png) no-repeat 0 0 / auto 90%;text-transform:lowercase}
+.posting-footer a.go-to-top-link{ padding-left:16px;background:url(images/arrow_up.png) no-repeat 0 0 / auto 90%}
 .posting-footer a.add-bookmark{padding-left:14px;background:url(images/bg_sprite_3.png) no-repeat 0 -97px}
 .posting-footer a.delete-bookmark{padding-left:14px;background:url(images/bg_sprite_3.png) no-repeat 0 -147px}
 .posting-footer a.move{padding-left:13px;background:url(images/bg_sprite_4.png) no-repeat 0 2px}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -58,7 +58,7 @@ img.show-sidebar{background:url(images/bg_sprite_2.png) no-repeat 0 -22px}
 #subnavmenu a.hierarchic{padding-left:13px;background:url(images/bg_sprite_1.png) no-repeat 0 -948px}
 #subnavmenu a.fold-postings{padding-left:13px;background:url(images/bg_sprite_1.png) no-repeat 0 -998px}
 a.rss{background:url(images/bg_sprite_1.png) no-repeat 3px -1048px}
-p.right a.rss,div.small a.rss{padding-left:15px}
+p.right a.rss{padding-left:15px}
 input.small,select.small{font-family:verdana,arial,sans-serif;font-size:.82em}
 #content{margin:0;padding:20px;min-height:200px;background:#fff}
 #content p,#content ul,#content td{font-size:.82em;line-height:1.5em;max-width:60em}

--- a/themes/default/subtemplates/thread.inc.tpl
+++ b/themes/default/subtemplates/thread.inc.tpl
@@ -88,4 +88,6 @@
 </div>
 {/function}
 {tree element=$tid}
-{if $settings.rss_feed==1}<div class="small" style="text-align:right;"><a class="rss" href="index.php?mode=rss&amp;thread={$tid}" title="{#rss_feed_thread_title#}">{#rss_feed_thread#}</a></div>{/if}
+{if $settings.rss_feed==1}<div class="complete-thread">
+<p class="right"><a class="rss" href="index.php?mode=rss&amp;thread={$tid}" title="{#rss_feed_thread_title#}">{#rss_feed_thread#}</a></p>
+</div>{/if}

--- a/themes/default/subtemplates/thread_linear.inc.tpl
+++ b/themes/default/subtemplates/thread_linear.inc.tpl
@@ -84,4 +84,6 @@
 </div>
 {/foreach}
 </div>
-{if $settings.rss_feed==1}<div class="small" style="text-align:right;"><a class="rss" href="index.php?mode=rss&amp;thread={$tid}">{#rss_feed_thread#}</a></div>{/if}
+{if $settings.rss_feed==1}<div class="complete-thread">
+<p class="right"><a class="rss" href="index.php?mode=rss&amp;thread={$tid}">{#rss_feed_thread#}</a></p>
+</div>{/if}

--- a/themes/default/subtemplates/thread_linear.inc.tpl
+++ b/themes/default/subtemplates/thread_linear.inc.tpl
@@ -85,5 +85,5 @@
 {/foreach}
 </div>
 {if $settings.rss_feed==1}<div class="complete-thread">
-<p class="right"><a class="rss" href="index.php?mode=rss&amp;thread={$tid}">{#rss_feed_thread#}</a></p>
+<p class="right"><a class="rss" href="index.php?mode=rss&amp;thread={$tid}" title="{#rss_feed_thread_title#}">{#rss_feed_thread#}</a></p>
 </div>{/if}


### PR DESCRIPTION
With the changes from #530, followed by fixes in #531 and #533 we encountered a few issues with RSS links in different views of entries and threads. After a research of the forum operator WorldofBB, documented in [this forum entry](https://mylittleforum.net/forum/index.php?id=12336), Micha added the proposed fix in #534. This pull request enhances the solution by unifying the HTML-structure in all three views to the one of the single-entry-view.

It was necessary to add an additional `div` to reflect the structure in the header above the thread tree of the single-entry-view even it has no function in the whole-thread-views. It should make the CSS a bit more maintainable. I would like it to remove the `div` again but in the single-entry-view it is needed and because of that it would come with the cost of the now removed additional selectors that was introduced with #534 ~~(this commit is not part of the pull request at time of its creation and will follow within a few minutes)~~.