### PR TITLE
Add optional attribute target with value '_blank' for links in entries 

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -404,9 +404,14 @@ function pagination($page_count,$page,$browse_range=3,$show_last=1)
  */
 function make_link($string)
  {
+ global $settings;
   $string = ' ' . $string;
   $string = preg_replace_callback("#(^|[\n ])([\w]+?://.*?[^ \"\n\r\t<]*)#is", "shorten_link", $string);
-  $string = preg_replace("#(^|[\n ])((www|ftp)\.[\w\-]+\.[\w\-.\~]+(?:/[^ \"\t\n\r<]*)?)#is", "$1<a href=\"http://$2\">$2</a>", $string);
+  if ($settings['link_open_target'] == 1) {
+    $string = preg_replace("#(^|[\n ])((www|ftp)\.[\w\-]+\.[\w\-.\~]+(?:/[^ \"\t\n\r<]*)?)#is", "$1<a href=\"http://$2\" target=\"_blank\">$2</a>", $string);
+  } else {
+    $string = preg_replace("#(^|[\n ])((www|ftp)\.[\w\-]+\.[\w\-.\~]+(?:/[^ \"\t\n\r<]*)?)#is", "$1<a href=\"http://$2\">$2</a>", $string);
+  }
   $string = my_substr($string, 1, my_strlen($string, CHARSET), CHARSET);
   return $string;
  }
@@ -509,6 +514,7 @@ function contains_invalid_string($string)
  */
 function do_bbcode_url ($action, $attributes, $content, $params, $node_object)
  {
+ global $settings;
   // 1) the code is validated
   if ($action == 'validate')
    {
@@ -525,10 +531,17 @@ function do_bbcode_url ($action, $attributes, $content, $params, $node_object)
   // 2) the code is outputed
   else
    {
-    // the code has been eneterd like this: [url]http://.../[/url]
-    if(!isset ($attributes['default'])) return '<a href="'.htmlspecialchars($content).'">'.htmlspecialchars(shorten_url($content)).'</a>';
-    // the code has been eneterd like this: [url=http://.../]Text[/url]
-    return '<a href="'.htmlspecialchars ($attributes['default']).'">'.$content.'</a>';
+     if ($settings['link_open_target'] == 1) {
+       // the code has been eneterd like this: [url]http://.../[/url]
+       if(!isset ($attributes['default'])) return '<a href="'.htmlspecialchars($content).'" target="_blank">'.htmlspecialchars(shorten_url($content)).'</a>';
+       // the code has been eneterd like this: [url=http://.../]Text[/url]
+       return '<a href="'.htmlspecialchars ($attributes['default']).'" target="_blank">'.$content.'</a>';
+     } else {
+       // the code has been eneterd like this: [url]http://.../[/url]
+       if(!isset ($attributes['default'])) return '<a href="'.htmlspecialchars($content).'">'.htmlspecialchars(shorten_url($content)).'</a>';
+       // the code has been eneterd like this: [url=http://.../]Text[/url]
+       return '<a href="'.htmlspecialchars ($attributes['default']).'">'.$content.'</a>';
+     }
    }
  }
 

--- a/install/install.sql
+++ b/install/install.sql
@@ -158,6 +158,7 @@ INSERT INTO mlf2_settings VALUES ('min_pw_special_characters', '0');
 INSERT INTO mlf2_settings VALUES ('php_mailer', '0');
 INSERT INTO mlf2_settings VALUES ('delete_inactive_users', '30');
 INSERT INTO mlf2_settings VALUES ('notify_inactive_users', '3');
+INSERT INTO mlf2_settings VALUES ('link_open_target', '0');
 
 INSERT INTO mlf2_temp_infos (`name`, `value`) VALUES ('access_permission_checks', '0'), ('last_changes', '0'), ('next_daily_actions', '0');
 

--- a/themes/default/main.tpl
+++ b/themes/default/main.tpl
@@ -1,4 +1,4 @@
-{config_load file=$language_file section="general"}{if $subnav_location && $subnav_location_var}{assign var="subnav_location" value=$smarty.config.$subnav_location|replace:"[var]":$subnav_location_var}{elseif $subnav_location}{assign var='subnav_location' value=$smarty.config.$subnav_location}{/if}<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+{config_load file=$language_file section="general"}{if $subnav_location && $subnav_location_var}{assign var="subnav_location" value=$smarty.config.$subnav_location|replace:"[var]":$subnav_location_var}{elseif $subnav_location}{assign var='subnav_location' value=$smarty.config.$subnav_location}{/if}<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="{#language#}" dir="{#dir#}">
 <head>
 <meta http-equiv="content-type" content="text/html; charset={#charset#}" />

--- a/update/update_2.4.19.1-2.5.php
+++ b/update/update_2.4.19.1-2.5.php
@@ -395,7 +395,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19.1',
 	if (!@mysqli_query($connid, "ALTER TABLE `" . $db_settings['userdata_table'] . "` ADD `inactivity_notification` BOOLEAN NOT NULL DEFAULT FALSE;")) {
 		$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 	}
-	if (!@mysqli_query($connid, "INSERT INTO `" . $db_settings['settings_table'] . "` (`name`, `value`) VALUES ('delete_inactive_users', '30'), ('notify_inactive_users', '3');")) {
+	if (!@mysqli_query($connid, "INSERT INTO `" . $db_settings['settings_table'] . "` (`name`, `value`) VALUES ('delete_inactive_users', '30'), ('notify_inactive_users', '3'), ('link_open_target', '0');")) {
 		$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 	}
 }


### PR DESCRIPTION
The pull request adds the often requested possibility to open external links in other browser windows or tabs. A new setting `link_open_target` was added and if-else-blocks in the functions `make_link` (for links, noted as pure text) and `do_bbcode_url` decides, if the attributes get added or not. The attribute has the hardcoded value `_blank`. The whole thing makes the use of attribute `target` mandatory. Therefore the doctype changed from XHTML 1 strict to transitional.

Links that was inserted with the bb-code `msg` (these are per definition forum internal links) should IMHO not be handled with the functionality (function `do_bbcode_msg`). We disabled this function for new entries a few versions ago but older forums will contain such entries almost certainly. So we have to deal with it.

If this proposal gets appreciated, we have to discuss the way to reinitialise the cache ([associated thread](https://mylittleforum.net/forum/index.php?id=12353) in the project forum).