### PR TITLE
Change: alter the doctype, change from XHTML 1.0 strict to transitional

### DIFF
--- a/themes/default/main.tpl
+++ b/themes/default/main.tpl
@@ -1,4 +1,4 @@
-{config_load file=$language_file section="general"}{if $subnav_location && $subnav_location_var}{assign var="subnav_location" value=$smarty.config.$subnav_location|replace:"[var]":$subnav_location_var}{elseif $subnav_location}{assign var='subnav_location' value=$smarty.config.$subnav_location}{/if}<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+{config_load file=$language_file section="general"}{if $subnav_location && $subnav_location_var}{assign var="subnav_location" value=$smarty.config.$subnav_location|replace:"[var]":$subnav_location_var}{elseif $subnav_location}{assign var='subnav_location' value=$smarty.config.$subnav_location}{/if}<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="{#language#}" dir="{#dir#}">
 <head>
 <meta http-equiv="content-type" content="text/html; charset={#charset#}" />


### PR DESCRIPTION
After discussing the failed attempt to add the possibility of activating the attribute target in links in entries (#540), we want to implement it in another way. The only one commit from the failed PR, that we can reuse, is the mandatiory change of the HTML dialect from XHTML 1 strict to XHTML 1 transitional.