### PR TITLE
get_magic_quotes_gpc

### DIFF
--- a/includes/main.inc.php
+++ b/includes/main.inc.php
@@ -4,18 +4,6 @@ if (!defined('IN_INDEX')) {
 	exit;
 }
 
-// stripslashes on GPC if magic_quotes_gpc is enabled:
-if (get_magic_quotes_gpc()) {
-	function stripslashes_deep($value) {
-		$value = is_array($value) ? array_map('stripslashes_deep', $value) : stripslashes($value);
-		return $value;
-	}
-	$_POST = array_map('stripslashes_deep', $_POST);
-	$_GET = array_map('stripslashes_deep', $_GET);
-	$_COOKIE = array_map('stripslashes_deep', $_COOKIE);
-	$_REQUEST = array_map('stripslashes_deep', $_REQUEST);
-}
-
 // database connection:
 $connid = connect_db($db_settings['host'], $db_settings['user'], $db_settings['password'], $db_settings['database']);
 


### PR DESCRIPTION
- `get_magic_quotes_gpc` is removed because this function returns always `false`
- `get_magic_quotes_gpc` is deprecated cf. https://www.php.net/manual/en/function.get-magic-quotes-gpc.php
- see also https://github.com/ilosuna/mylittleforum/issues/552