### PR TITLE
PHP 8: Comment symbol

### DIFF
--- a/includes/avatar.inc.php
+++ b/includes/avatar.inc.php
@@ -30,7 +30,6 @@ if ($settings['avatars'] > 0 && isset($_SESSION[$settings['session_prefix'].'use
 
 		if(empty($errors)) {
 			if($_FILES['probe']['size'] > $settings['avatar_max_filesize']*1000 || $image_info[0] > $settings['avatar_max_width'] || $image_info[1] > $settings['avatar_max_height']) {
-				#$compression = 10;
 				$width  = $image_info[0];
 				$height = $image_info[1];
 

--- a/includes/classes/Backup.class.php
+++ b/includes/classes/Backup.class.php
@@ -32,7 +32,6 @@ class Backup
 
   function assign($data)
    {
-    #$this->dump .= utf8_encode($data);
     $this->dump .= $data;
     $this->queries++;
 
@@ -70,9 +69,9 @@ class Backup
        }
       if($handle = @fopen($this->file, 'a+'))
        {
-        #flock($fp, 2);
+        // flock($fp, 2);
         @fwrite($handle, $this->dump);
-        #flock($fp, 3);
+        // flock($fp, 3);
         @fclose($handle);
         $this->dump = '';
        }

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -170,7 +170,6 @@ function daily_actions($current_time=0) {
 		else {
 			$next_daily_actions = $current_time + 86400;
 		}
-		#@mysqli_query($connid, "UPDATE ".$db_settings['settings_table']." SET value='".intval($next_daily_actions)."' WHERE name='next_daily_actions'");
 		@mysqli_query($connid, "UPDATE " . $db_settings['temp_infos_table'] . " SET value='" . intval($next_daily_actions) . "', time = NOW() WHERE name='next_daily_actions'");
 	}
 }
@@ -573,7 +572,6 @@ function do_bbcode_img($action, $attributes, $content, $params, $node_object) {
 			$size = @getimagesize($content);
 			if ($size !== false && (is_numeric($size[0]) && $size[0] > 0) && (is_numeric($size[1]) && $size[1] > 0)) {
 				$strSize = $size[3];
-				#$strSize = 'width="256" height="256"';
 			}
 		}
 		if (isset($attributes['default']) && $attributes['default'] == 'left') return '<img src="'. htmlspecialchars($content) .'" class="left" alt="[image]" '. $strSize .' />';
@@ -638,10 +636,10 @@ function do_bbcode_color($action, $attributes, $content, $params, $node_object)
 function do_bbcode_size($action, $attributes, $content, $params, $node_object)
  {
   // font size definitions:
-  #$size['tiny'] = 'x-small';
+  // $size['tiny'] = 'x-small';
   $size['small'] = 'smaller';
   $size['large'] = 'large';
-  #$size['huge'] = 'x-large';
+  // $size['huge'] = 'x-large';
   // end font size definitions
 
   if($action == 'validate')
@@ -755,9 +753,9 @@ function do_bbcode_code($action, $attributes, $content, $params, $node_object)
   if ($action == 'validate')
    {
     // [code]...[/code]
-    #if(!isset($attributes['default'])) return true;
+    // if(!isset($attributes['default'])) return true;
     // [code=lang]image[/code]
-    #if(in_array(strtolower($attributes['default']),explode(',',$settings['syntax_highlighter_languages']))) return true;
+    // if(in_array(strtolower($attributes['default']),explode(',',$settings['syntax_highlighter_languages']))) return true;
     return true;
    }
   else
@@ -769,9 +767,9 @@ function do_bbcode_code($action, $attributes, $content, $params, $node_object)
      {
       include_once('modules/geshi/geshi.php');
       $geshi = new GeSHi($content, $attributes['default']);
-      #$geshi->set_header_type(GESHI_HEADER_NONE);
-      #$geshi->enable_line_numbers(GESHI_FANCY_LINE_NUMBERS, 1);
-      #$geshi->set_line_style('background:#f5f5f5;', 'background:#f9f9f9;');
+      // $geshi->set_header_type(GESHI_HEADER_NONE);
+      // $geshi->enable_line_numbers(GESHI_FANCY_LINE_NUMBERS, 1);
+      // $geshi->set_line_style('background:#f5f5f5;', 'background:#f9f9f9;');
       $geshi->enable_keyword_links(false);
       $geshi->set_overall_class(false);
       return $geshi->parse_code();
@@ -992,7 +990,7 @@ function html_format($string){
 	$bbcode->setCodeFlag ('quote', 'closetag.after.newline', BBCODE_NEWLINE_IGNORE);
 	$bbcode->setCodeFlag ('quote', 'opentag.before.newline', BBCODE_NEWLINE_DROP);
 	$bbcode->setCodeFlag ('quote', 'closetag.before.newline', BBCODE_NEWLINE_DROP);
-	#$bbcode->setCodeFlag ('quote', 'closetag', BBCODE_CLOSETAG_OPTIONAL);
+	// $bbcode->setCodeFlag ('quote', 'closetag', BBCODE_CLOSETAG_OPTIONAL);
 	
 	$bbcode->addCode ('rtl', 'simple_replace', null, array ('start_tag' => '<div dir="rtl">', 'end_tag' => '</div>'), 'rtl', array ('block','rtl'), array ('ltr'));
 	$bbcode->setCodeFlag ('rtl', 'paragraphs', true);
@@ -1017,9 +1015,9 @@ function html_format($string){
 		$bbcode->addCode ('url', 'usecontent?', 'do_bbcode_url', array ('usecontent_param' => 'default'), 'link', array ('listitem', 'block', 'inline', 'quote', 'pre', 'monospace', 'rtl', 'ltr'), array ('link'));
 		$bbcode->addCode ('link', 'usecontent?', 'do_bbcode_url', array ('usecontent_param' => 'default'), 'link', array ('listitem', 'block', 'inline', 'quote', 'pre', 'monospace', 'rtl', 'ltr'), array ('link'));
 		$bbcode->addCode ('msg', 'usecontent?', 'do_bbcode_msg', array ('usecontent_param' => 'default'), 'link', array ('listitem', 'block', 'inline', 'quote', 'pre', 'monospace', 'rtl', 'ltr'), array ('link'));
-		#$bbcode->setOccurrenceType ('img', 'image');
-		#$bbcode->setMaxOccurrences ('image', 2);
-		#$bbcode->addCode ('code', 'simple_replace', null, array ('start_tag' => '<pre><code>', 'end_tag' => '</code></pre>'), 'code', array ('block','quote'), array ());
+		// $bbcode->setOccurrenceType ('img', 'image');
+		// $bbcode->setMaxOccurrences ('image', 2);
+		// $bbcode->addCode ('code', 'simple_replace', null, array ('start_tag' => '<pre><code>', 'end_tag' => '</code></pre>'), 'code', array ('block','quote'), array ());
 		
 		$bbcode->addParser ('list', 'bbcode_stripcontents');
 		$bbcode->addCode ('list', 'simple_replace', null, array ('start_tag' => '<ul>', 'end_tag' => '</ul>'), 'list', array ('block', 'listitem', 'quote', 'rtl', 'ltr'), array ());
@@ -1029,7 +1027,7 @@ function html_format($string){
 		$bbcode->setCodeFlag ('list', 'closetag.before.newline', BBCODE_NEWLINE_DROP);
 		$bbcode->addCode ('*', 'simple_replace', null, array ('start_tag' => '<li>', 'end_tag' => '</li>'), 'listitem', array ('list'), array ());
 		$bbcode->setCodeFlag ('*', 'closetag', BBCODE_CLOSETAG_OPTIONAL);
-		#$bbcode->setCodeFlag ('*', 'paragraphs', true);
+		// $bbcode->setCodeFlag ('*', 'paragraphs', true);
 	
 		if($settings['bbcode_code']==1) {
 			$bbcode->addCode ('code', 'usecontent', 'do_bbcode_code', array (), 'code', array ('block', 'quote', 'rtl', 'ltr'), array ());
@@ -1040,7 +1038,7 @@ function html_format($string){
 			$bbcode->addCode('monospace', 'simple_replace', null, array ('start_tag' => '<code class="monospace">', 'end_tag' => '</code>'), 'monospace', array ('listitem', 'block', 'inline', 'link', 'quote', 'rtl', 'ltr'), array ());
 			$bbcode->addCode('pre', 'simple_replace', null, array ('start_tag' => '<pre>', 'end_tag' => '</pre>'), 'pre', array ('block', 'quote', 'rtl', 'ltr'), array ());
 			$bbcode->setCodeFlag('pre', 'paragraph_type', BBCODE_PARAGRAPH_BLOCK_ELEMENT);
-			#$bbcode->addCode('inlinepre', 'simple_replace', null, array ('start_tag' => '<pre class="inline">', 'end_tag' => '</pre>'), 'inlinepre', array ('listitem', 'block', 'inline', 'link', 'quote', 'rtl', 'ltr'), array ());
+			// $bbcode->addCode('inlinepre', 'simple_replace', null, array ('start_tag' => '<pre class="inline">', 'end_tag' => '</pre>'), 'inlinepre', array ('listitem', 'block', 'inline', 'link', 'quote', 'rtl', 'ltr'), array ());
 		}
 		if($settings['bbcode_img']==1) {
 			$bbcode->addCode ('img', 'usecontent', 'do_bbcode_img', array (), 'image', array ('listitem', 'block', 'inline', 'link', 'quote', 'rtl', 'ltr'), array ());
@@ -1092,13 +1090,13 @@ function signature_format($string) {
 		$bbcode->addCode ('url', 'usecontent?', 'do_bbcode_url', array ('usecontent_param' => 'default'), 'link', array ('listitem', 'block', 'inline', 'quote', 'rtl', 'ltr'), array ('link'));
 		$bbcode->addCode ('link', 'usecontent?', 'do_bbcode_url', array ('usecontent_param' => 'default'), 'link', array ('listitem', 'block', 'inline', 'quote', 'rtl', 'ltr'), array ('link'));
 		$bbcode->addCode ('color', 'callback_replace', 'do_bbcode_color', array ('usecontent_param' => 'default'), 'inline', array ('listitem', 'block', 'inline', 'link', 'quote', 'rtl', 'ltr'), array ());
-		#$bbcode->setOccurrenceType ('img', 'image');
-		#$bbcode->setMaxOccurrences ('image', 2);
+		// $bbcode->setOccurrenceType ('img', 'image');
+		// $bbcode->setMaxOccurrences ('image', 2);
 		if($settings['bbcode_img'] == 1) {
 			$bbcode->addCode ('img', 'usecontent', 'do_bbcode_img', array (), 'image', array ('listitem', 'block', 'inline', 'link', 'quote', 'rtl', 'ltr'), array ());
 		}
 	}
-	#$bbcode->setRootParagraphHandling(true);
+	// $bbcode->setRootParagraphHandling(true);
 	$string = $bbcode->parse($string);
 	return $string;
 }
@@ -1132,7 +1130,7 @@ function email_format($string) {
 		$bbcode->addCode ('list', 'simple_replace', null, array ('start_tag' => '', 'end_tag' => ''), 'list', array ('block', 'listitem', 'rtl', 'ltr'), array ());
 		$bbcode->addCode ('*', 'simple_replace', null, array ('start_tag' => '* ', 'end_tag' => ''), 'listitem', array ('list'), array ());
 		$bbcode->setCodeFlag ('*', 'closetag', BBCODE_CLOSETAG_OPTIONAL);
-		#$bbcode->addCode ('code', 'simple_replace', null, array ('start_tag' => '', 'end_tag' => ''), 'code', array ('block', 'inline'), array ());
+		// $bbcode->addCode ('code', 'simple_replace', null, array ('start_tag' => '', 'end_tag' => ''), 'code', array ('block', 'inline'), array ());
 		if($settings['bbcode_code']==1){
 			$bbcode->addCode('code', 'usecontent', 'do_bbcode_code_email', array (), 'code', array ('block', 'quote', 'rtl', 'ltr'), array ());
 			$bbcode->addCode ('pre', 'simple_replace', null, array ('start_tag' => '', 'end_tag' => ''), 'pre', array ('block', 'quote', 'rtl', 'ltr'), array ());
@@ -1230,8 +1228,6 @@ function user_online($user_online_period=10)
   list($is_online) = @mysqli_fetch_row(@mysqli_query($connid, "SELECT COUNT(*) FROM ".$db_settings['useronline_table']." WHERE ip= '".$ip."'"));
   if ($is_online > 0) @mysqli_query($connid, "UPDATE ".$db_settings['useronline_table']." SET time='".TIMESTAMP."', user_id='".$user_id."' WHERE ip='".$ip."'");
   else @mysqli_query($connid, "INSERT INTO ".$db_settings['useronline_table']." SET time='".TIMESTAMP."', ip='".$ip."', user_id='".$user_id."'");
-  #list($user_online) = @mysqli_fetch_row(@mysqli_query($connid, "SELECT COUNT(*) FROM ".$db_settings['useronline_table']));
-  #return $user_online;
  }
 
 /**
@@ -1401,20 +1397,20 @@ function emailNotification2ParentAuthor($id, $delayed = false) {
 	$resultNewPosting = @mysqli_query($connid, $queryNewPosting);
 	$data = mysqli_fetch_assoc($resultNewPosting);
 	mysqli_free_result($resultNewPosting);
-	# overwrite $data['name'] with $data['user_name'] if registered user:
+	// overwrite $data['name'] with $data['user_name'] if registered user:
 	if ($data['user_id'] > 0) {
 		if (!$data['user_name']) $data['name'] = $lang['unknown_user'];
 		else $data['name'] = $data['user_name'];
 	}
-	# if it's a reply (pid!=0) check if notification was desired by parent posting author:
+	// if it's a reply (pid!=0) check if notification was desired by parent posting author:
 	if ($data['pid'] != 0) {
 		$parentSubscriptions = mysqli_query($connid, "SELECT user_id, eid, unsubscribe_code, 'child' AS type FROM " . $db_settings['subscriptions_table'] . " WHERE eid = " . intval($data['pid']) . " UNION SELECT user_id, eid, unsubscribe_code, 'opener' AS type FROM " . $db_settings['subscriptions_table'] . " WHERE eid = " . intval($data['tid']));
 		while ($parent_data = mysqli_fetch_assoc($parentSubscriptions)) {
 			if ($parent_data['user_id'] > 0) {
-				# user_id is greater than 0 and therefore we handle a subscription of a registered user
+				// user_id is greater than 0 and therefore we handle a subscription of a registered user
 				$queryEmailData = "SELECT user_id, user_name, user_email FROM " . $db_settings['userdata_table'] . " WHERE user_id = " . intval($parent_data['user_id']);
 			} else {
-				# user_id is 0 and therefore we handle a subscription of an unregistered user
+				// user_id is 0 and therefore we handle a subscription of an unregistered user
 				$queryEmailData = "SELECT user_id, name AS user_name, email AS user_email FROM ".$db_settings['forum_table']." WHERE id = " . intval($parent_data['eid']) . " LIMIT 1";
 			}
 			$resultEmailData = @mysqli_query($connid, $queryEmailData);
@@ -1691,7 +1687,6 @@ function get_edit_authorization($id, $posting_user_id, $edit_key, $time, $locked
 
   $reply_result = mysqli_query($connid, "SELECT COUNT(*) FROM ".$db_settings['forum_table']." WHERE pid = ".intval($id));
   list($replies) = mysqli_fetch_row($reply_result);
-  #$authorization['replies'] = $replies;
 
   if($settings['edit_min_time_period'] != 0 && (TIMESTAMP - $settings['edit_min_time_period']*60) < $time) $edit_min_time_period_expired = false;
   else $edit_min_time_period_expired = true;
@@ -1750,7 +1745,7 @@ function get_edit_authorization($id, $posting_user_id, $edit_key, $time, $locked
 function create_backup_file($mode=0)
  {
   global $settings, $db_settings, $connid;
-  #@set_time_limit(30);
+  // @set_time_limit(30);
   $mode=intval($mode);
   if($mode<0 || $mode > 10) $mode = 0;
 
@@ -1978,7 +1973,6 @@ function create_backup_file($mode=0)
       $data['email'] = mysqli_real_escape_string($connid, $data['email']);
       $data['location'] = mysqli_real_escape_string($connid, $data['location']);
       $data['ip'] = mysqli_real_escape_string($connid, $data['ip']);
-      #$data['text'] = iconv("UTF-8","ISO-8859-1",$data['text']);
       $data['text'] = mysqli_real_escape_string($connid, $data['text']);
       $data['text'] = str_replace("\r", "\\r", $data['text']);
       $data['text'] = str_replace("\n",  "\\n", $data['text']);
@@ -2017,7 +2011,7 @@ function restore_backup($backup_file)
   @mysqli_query($connid, "START TRANSACTION") or die(mysqli_error($connid));
   while (!feof($handle))
    {
-    #$buffer = fgets($handle, 20480);
+    // $buffer = fgets($handle, 20480);
     $buffer = fgets($handle);
     $buffer = trim($buffer);
     if(my_substr($buffer, -1, my_strlen($buffer, CHARSET), CHARSET)==';') $buffer = my_substr($buffer,0,-1,CHARSET);
@@ -2635,7 +2629,6 @@ function checkUpdate($currentVersion = '0.0') {
 		$lastVersion                  = $xml->xpath("//atom:entry[1]/atom:id");
 		$updateDateOfInstalledVersion = $xml->xpath("//atom:entry/atom:id[substring(text(), string-length(text()) - string-length('" . htmlspecialchars($currentVersion) . "') + 1) = '" . htmlspecialchars($currentVersion) . "']/../atom:updated");	
 		$updateDateOfActualVersion = strtotime($updateDateOfActualVersion[0]);
-		//$lastVersion = preg_replace ("/.+\/v/u", "", $lastVersion[0]);
 		$lastVersion = preg_replace("/.*?([^\/v?]+$)/u", "$1", $lastVersion[0]);
 
 		if (empty($updateDateOfInstalledVersion))
@@ -2652,7 +2645,6 @@ function checkUpdate($currentVersion = '0.0') {
 				'title'   => (string)$title[0],
 				'content' => (string)$content[0],
 				'version' => (string)$lastVersion,
-				//'uri'     => $baseURI . (string)$releaseURI[0]->href
 				'uri'     => (string)$releaseURI[0]->href
 			);
 			return $release;
@@ -2667,13 +2659,13 @@ function checkUpdate($currentVersion = '0.0') {
  * @param string $string
  * @reurn bool
  */
-function contains_special_characters($string)
- {
-  #if(!preg_match("/^[a-zA-Z0-9_\- ]+$/", $string)) return true; // only alphanumeric characters, "-", "_" and " " allowed
-  if(preg_match("/([[:cntrl:]]|\p{Cf})/u", $string)) return true; // control characters and soft hyphen
-  if(preg_match("/(\x{200b})/u", $string)) return true; // zero width space
-  return false;
- }
+function contains_special_characters($string) {
+	if(preg_match("/([[:cntrl:]]|\p{Cf})/u", $string)) 
+		return true; // control characters and soft hyphen
+	if(preg_match("/(\x{200b})/u", $string)) 
+		return true; // zero width space
+	return false;
+}
 
 /**
  * gets available timezones
@@ -2981,12 +2973,12 @@ function raise_error($error,$error_message='') {
 	<meta http-equiv="content-type" content="text/html; charset=<?php echo $lang['charset']; ?>" />
 	<style type="text/css">
 	<!--
-	body              { color:#000; background:#fff; margin:0; padding:0; font-family: verdana, arial, sans-serif; font-size:100.1%; }
-	h1                { font-size:1.25em; }
-	p,ul              { font-size:0.82em; line-height:1.45em; }
-	#top              { margin:0; padding:0 20px 0 20px; height:4.4em; color:#000000; background:#d2ddea; border-bottom: 1px solid #bacbdf; line-height:4.4em;}
-	#top h1           { font-size:1.7em; margin:0; padding:0; color:#000080; }
-	#content          { padding:20px; }
+	body               { color:#000; background:#fff; margin:0; padding:0; font-family: verdana, arial, sans-serif; font-size:100.1%; }
+	h1                 { font-size:1.25em; }
+	p,ul               { font-size:0.82em; line-height:1.45em; }
+	//top              { margin:0; padding:0 20px 0 20px; height:4.4em; color:#000000; background:#d2ddea; border-bottom: 1px solid #bacbdf; line-height:4.4em;}
+	//top h1           { font-size:1.7em; margin:0; padding:0; color:#000080; }
+	//content          { padding:20px; }
 	-->
 	</style>
 	</head>

--- a/includes/index.inc.php
+++ b/includes/index.inc.php
@@ -219,7 +219,6 @@ $page_count = ceil($total_threads / $settings['threads_per_page']);
 $subnav_link = array('mode'=>'posting', 'title'=>'new_topic_link_title', 'name'=>'new_topic_link');
 
 if (isset($data_array)) $smarty->assign('data', $data_array);
-#if (isset($tree)) $smarty->assign("tree", $tree);
 if (isset($threads)) {
 	$smarty->assign("threads", $threads);
 	$smarty->assign('replies', $replies);

--- a/includes/login.inc.php
+++ b/includes/login.inc.php
@@ -170,16 +170,16 @@ switch ($action) {
 		exit;
 	break;
 	case "dps":
-		# the user has to accept (again) the data privacy statement
+		// the user has to accept (again) the data privacy statement
 		if ($settings['data_privacy_agreement'] == 1 && isset($_SESSION[$settings['session_prefix'].'user_id'])) {
-			# user is logged in and accepting of the data privacy statement is necessary
+			// user is logged in and accepting of the data privacy statement is necessary
 			$resultDPS = mysqli_query($connid, "SELECT dps_accepted, tou_accepted FROM ".$db_settings['userdata_table']." WHERE user_id = ". intval($_SESSION[$settings['session_prefix'].'user_id'])) or raise_error('database_error', mysqli_error($connid));
 			$feld = mysqli_fetch_assoc($resultDPS);
 			if ($feld['dps_accepted'] === NULL) {
-				# display the form for accepting the data privacy statement
+				// display the form for accepting the data privacy statement
 				$action = 'show_dps';
 			} else {
-				# data privacy statement was accepted before, redirect
+				// data privacy statement was accepted before, redirect
 				if ($settings['terms_of_use_agreement'] == 1 && $feld['tou_accepted'] === NULL) {
 					$redir = 'index.php?mode=login&action=tou';
 				} else if (isset($_SESSION[$settings['session_prefix'].'last_visited_uri'])) {
@@ -191,22 +191,22 @@ switch ($action) {
 				exit;
 			}
 		} else {
-			# redirect to the index view
+			// redirect to the index view
 			header("location: index.php");
 			exit;
 		}
 	break;
 	case "tou":
-		# the user has to accept (again) the terms of use
+		// the user has to accept (again) the terms of use
 		if ($settings['terms_of_use_agreement'] == 1 && isset($_SESSION[$settings['session_prefix'].'user_id'])) {
-			# user is logged in and accepting of the terms of use agreement is necessary
+			// user is logged in and accepting of the terms of use agreement is necessary
 			$resultTOU = mysqli_query($connid, "SELECT dps_accepted, tou_accepted FROM ".$db_settings['userdata_table']." WHERE user_id = ". intval($_SESSION[$settings['session_prefix'].'user_id'])) or raise_error('database_error', mysqli_error($connid));
 			$feld = mysqli_fetch_assoc($resultTOU);
 			if ($feld['tou_accepted'] === NULL) {
-				# display the form for accepting the terms of use agreement
+				// display the form for accepting the terms of use agreement
 				$action = 'show_tou';
 			} else {
-				# terms of use agreement was accepted before, redirect
+				// terms of use agreement was accepted before, redirect
 				if ($settings['data_privacy_agreement'] == 1 && $feld['dps_accepted'] === NULL) {
 					$redir = 'index.php?mode=login&action=dps';
 				} else if (isset($_SESSION[$settings['session_prefix'].'last_visited_uri'])) {
@@ -218,7 +218,7 @@ switch ($action) {
 				exit;
 			}
 		} else {
-			# redirect to the index view
+			// redirect to the index view
 			header("location: index.php");
 			exit;
 		}
@@ -230,7 +230,7 @@ switch ($action) {
 			if ($feld['dps_accepted'] === NULL) {
 				$writeDPS = mysqli_query($connid, "UPDATE ".$db_settings['userdata_table']." SET dps_accepted = NOW() WHERE user_id = ". intval($_SESSION[$settings['session_prefix'].'user_id'])) or raise_error('database_error', mysqli_error($connid));
 			}
-			# data privacy statement got accepted, redirect
+			// data privacy statement got accepted, redirect
 			if ($settings['terms_of_use_agreement'] == 1 && $feld['tou_accepted'] === NULL) {
 				$redir = 'index.php?mode=login&action=tou';
 			} else if (isset($_SESSION[$settings['session_prefix'].'last_visited_uri'])) {
@@ -257,7 +257,7 @@ switch ($action) {
 			if ($feld['tou_accepted'] === NULL) {
 				$writeTOU = mysqli_query($connid, "UPDATE ".$db_settings['userdata_table']." SET tou_accepted = NOW() WHERE user_id = ". intval($_SESSION[$settings['session_prefix'].'user_id'])) or raise_error('database_error', mysqli_error($connid));
 			}
-			# terms of use got accepted, redirect
+			// terms of use got accepted, redirect
 			if ($settings['data_privacy_agreement'] == 1 && $feld['dps_accepted'] === NULL) {
 				$redir = 'index.php?mode=login&action=dps';
 			} else if (isset($_SESSION[$settings['session_prefix'].'last_visited_uri'])) {

--- a/includes/posting.inc.php
+++ b/includes/posting.inc.php
@@ -314,7 +314,7 @@ if ($action == 'unsubscribe' and !empty($_GET['unsubscribe'])) {
 	}
 }
 
-# generate the variable input field names
+// generate the variable input field names
 $fname_user = hash("sha256", 'user_name' . $_SESSION['csrf_token']);
 $fname_email = hash("sha256", 'user_email' . $_SESSION['csrf_token']);
 $fname_phone = hash("sha256", 'phone' . $_SESSION['csrf_token']);
@@ -1339,7 +1339,7 @@ switch ($action) {
 		$field = mysqli_fetch_array($edit_result);
 		$field['tags'] = getEntryTags($id);
 		mysqli_free_result($edit_result);
-		# check for notification
+		// check for notification
 		if ($field['user_id'] > 0) {
 			$subscription = @mysqli_query($connid, "SELECT eid FROM " . $db_settings['subscriptions_table'] . " WHERE eid = " . intval($id) . " AND user_id = " . intval($field['user_id'])) or raise_error('database_error', mysqli_error($connid));
 		} else {

--- a/includes/thread.inc.php
+++ b/includes/thread.inc.php
@@ -191,7 +191,6 @@ if (is_array($category_ids) && !in_array($data['category'], $category_ids)) {
 						// cache signature:
 						$xxx = mysqli_query($connid, "SELECT COUNT(*) FROM " . $db_settings['userdata_cache_table'] . " WHERE cache_id=" . intval($data['user_id'])) or die(mysqli_error($connid));
 						list($row_count) = mysqli_fetch_row($xxx);
-						#echo 'row count: '.$row_count.' user_id: '.$data['user_id'].'<br />';
 						if ($row_count == 1) {
 							@mysqli_query($connid, "UPDATE " . $db_settings['userdata_cache_table'] . " SET cache_signature='" . mysqli_real_escape_string($connid, $data['signature']) . "' WHERE cache_id=" . intval($data['user_id']));
 						} else {

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -87,8 +87,8 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 		}
 		if (empty($errors)) {
 			@chmod($uploaded_images_path.$filename, 0644);
-			# $user_id can be NULL (see around line #15), because of that do not handle it with intval()
-			# see therefore variable definition of $user_id around line 15 of this script
+			// $user_id can be NULL (see around line #15), because of that do not handle it with intval()
+			// see therefore variable definition of $user_id around line 15 of this script
 			$qSetUpload = "INSERT INTO " . $db_settings['uploads_table'] . " (uploader, filename, tstamp) VALUES (". $user_id .", '" . mysqli_real_escape_string($connid, $filename) . "', NOW())";
 			mysqli_query($connid, $qSetUpload);
 			$smarty->assign('uploaded_file', $filename);


### PR DESCRIPTION
- in PHP 8, # is no longer interpreted as the start of a comment, as this syntax is now used for attributes, cf. https://www.php.net/manual/en/migration80.incompatible.php, #552 
- comments are removed, if they are identified as /obsolete fragments/, i.e., former code/debugging code
- comment symbol '#' is replaced by '//'