### PR TITLE
get_magic_quotes_gpc removed

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -28,18 +28,6 @@ $default_settings['forum_name'] = 'my little forum';
 $default_settings['forum_address'] = ((isProtocolHTTPS() === true) ? 'https' : 'http') .'://'. $_SERVER['HTTP_HOST'] . substr(rtrim(dirname($_SERVER['SCRIPT_NAME']), '/\\'), 0, strrpos(rtrim(dirname($_SERVER['SCRIPT_NAME']), '/\\'), '/')) . '/';
 $default_settings['table_prefix'] = 'mlf2_';
 
-// stripslashes on GPC if get_magic_quotes_gpc is enabled:
-if (get_magic_quotes_gpc()) {
-	function stripslashes_deep($value) {
-		$value = is_array($value) ? array_map('stripslashes_deep', $value) : stripslashes($value);
-		return $value;
-	}
-	$_POST = array_map('stripslashes_deep', $_POST);
-	$_GET = array_map('stripslashes_deep', $_GET);
-	$_COOKIE = array_map('stripslashes_deep', $_COOKIE);
-	$_REQUEST = array_map('stripslashes_deep', $_REQUEST);
-}
-
 function table_exists($table) {
 	global $connid;
 	$result = @mysqli_query($connid, "SHOW TABLES");


### PR DESCRIPTION
- get_magic_quotes_gpc removed because this function returns alwas false
- get_magic_quotes_gpc is deprecated cf. https://www.php.net/manual/en/function.get-magic-quotes-gpc.php
- see also #552, #553