### PR TITLE
Update index.php

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -42,7 +42,7 @@ if(!file_exists('../config/VERSION')) {
 	die('Error in line '.__LINE__.': Missing the file config/VERSION.');
 } else {
 	$newVersion = file_get_contents('../config/VERSION');
-	if (empty($newVersion) die('Error in line '.__LINE__.': No value for the script version in the file config/VERSION.');
+	if (empty($newVersion)) die('Error in line '.__LINE__.': No value for the script version in the file config/VERSION.');
 	else $newVersion = trim($newVersion);
 }
 


### PR DESCRIPTION
Hello @auge8472,

I was in the process of manual installation of My little forum 20220508.1 on Centos 7 with  PHP 7.0, MYSQL 5.5, Apache 2.2
However while starting the installation I get this error.

Parse error: syntax error, unexpected 'die' (T_EXIT) in {{/PATH}}/{{TO}}/{{MLF}}/install/index.php on line 45. 

There is a round brace which isn't closed properly on line 45 i.e : 

`if (empty($newVersion) die('Error in line '.__LINE__.': No value for the script version in the file config/VERSION.');`

instead of this : 

`if (empty($newVersion)) die('Error in line '.__LINE__.': No value for the script version in the file config/VERSION.');`

The following PR fixes the issue. Please accept the PR.