### PR TITLE
Convert the main structure to be HTML5-based

### DIFF
--- a/themes/default/main.tpl
+++ b/themes/default/main.tpl
@@ -57,7 +57,6 @@
 </head>
 
 <body class="tex2jax_ignore">
-<!--[if IE]><div id="ie"><![endif]-->
 
 <div id="top">
 
@@ -107,8 +106,6 @@ Please donate if you want to remove this link:
 https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=1922497
 *}
 <div id="pbmlf"><a href="https://mylittleforum.net/">powered by my little forum</a></div>
-
-<!--[if IE]></div><![endif]-->
 
 </body>
 </html>

--- a/themes/default/main.tpl
+++ b/themes/default/main.tpl
@@ -58,7 +58,7 @@
 
 <body class="tex2jax_ignore">
 
-<div id="top">
+<header id="top">
 
 <div id="logo">
 {if $settings.home_linkname}<p class="home"><a href="{$settings.home_linkaddress}">{$settings.home_linkname}</a></p>{/if}
@@ -73,22 +73,22 @@
 {/if}
 </ul>
 <form id="topsearch" action="index.php" method="get" title="{#search_title#}" accept-charset="{#charset#}"><div><input type="hidden" name="mode" value="search" /><label for="search-input">{#search_marking#}</label>&nbsp;<input id="search-input" type="text" name="search" value="{#search_default_value#}" /><!--&nbsp;<input type="image" src="templates/{$settings.template}/images/submit.png" alt="[&raquo;]" />--></div></form></div>
-</div>
+</header>
 
-<div id="subnav">
+<nav id="subnav">
 <div id="subnav-1">{include file="$theme/subtemplates/subnavigation_1.inc.tpl"}</div>
 <div id="subnav-2">{include file="$theme/subtemplates/subnavigation_2.inc.tpl"}</div>
-</div>
+</nav>
 
-<div id="content">
+<main id="content">
 {if $subtemplate}
 {include file="$theme/subtemplates/$subtemplate"}
 {else}
 {$content|default:""}
 {/if}
-</div>
+</main>
 
-<div id="footer">
+<footer id="footer">
 <div id="footer-1">{if $total_users_online}{#counter_users_online#|replace:"[total_postings]":$total_postings|replace:"[total_threads]":$total_threads|replace:"[registered_users]":$registered_users|replace:"[total_users_online]":$total_users_online|replace:"[registered_users_online]":$registered_users_online|replace:"[unregistered_users_online]":$unregistered_users_online}{else}{#counter#|replace:"[total_postings]":$total_postings|replace:"[total_threads]":$total_threads|replace:"[registered_users]":$registered_users}{/if}<br />
 {if $forum_time_zone}{#forum_time_with_time_zone#|replace:'[time]':$forum_time|replace:'[time_zone]':$forum_time_zone}{else}{#forum_time#|replace:'[time]':$forum_time}{/if}</div>
 <div id="footer-2">
@@ -99,13 +99,13 @@
  <li><a href="index.php?mode=contact" title="{#contact_linktitle#}" rel="nofollow">{#contact_link#}</a></li>
 </ul>
 </div>
-</div>
-
 {*
 Please donate if you want to remove this link:
 https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=1922497
 *}
 <div id="pbmlf"><a href="https://mylittleforum.net/">powered by my little forum</a></div>
+</footer>
+
 
 </body>
 </html>

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -7,7 +7,7 @@
 * <https://yui.github.io/yuicompressor/>.                              *
 ***********************************************************************/
 
-body                     { color:#000; background:#f9f9f9; margin:0; padding:0; font-family:verdana,arial,sans-serif; font-size:1em; }
+body                     { color:#000; background:#f9f9f9; margin:0; padding:0; font-family:verdana,arial,sans-serif; font-size:1em; display:flex; flex-direction:column; min-height:100vh; }
 h1                       { margin-top:0; font-size:1.25em; font-weight:bold; }
 h2                       { margin-top:20px; font-size:1.25em; font-weight:bold; }
 p                        { margin-top:0; }
@@ -87,7 +87,7 @@ p.right a.rss            { padding-left:15px; }
 input.small,
 select.small             { font-family:verdana,arial,sans-serif; font-size:0.82em; }
 
-#content                 { margin:0; padding:20px; min-height:200px; background:#fff; }
+#content                 { margin:0; padding:20px; min-height:200px; background:#fff; flex:1; }
 #content p,
 #content ul,
 #content td              { font-size:0.82em; line-height:1.5em; max-width:60em; }

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -667,23 +667,6 @@ img.right                { float:right; margin:0 0 10px 10px; }
 #image-canvas            { position:absolute; top:0; left:0; width:100%; height:100%; background:url(images/canvas_bg.png); z-index:20; }
 #image-canvas img        { display:block; margin:2em auto 0 auto; border:1px solid #000; z-index:30; max-width:90%; }
 
-/* IE: */
-#ie ul.reply             { width:100%; }
-#ie ul.reply ul          { background:none; }
-#ie ul.thread li         { height:100%;  }
-/* IE 6: */
-* html #ie ul.thread     { margin-left:-18px; }
-* html #ie ul.thread li  { text-indent:0; }
-* html #ie #usermenu li  { margin-left:5px; padding-left:5px; background:none; }
-* html #ie #subnav #subnav-2
-                         { padding-top:0.4em; }
-* html #ie #footermenu li
-                         { margin-left:5px; padding-left:5px; background:none; }
-* html #ie div.complete-thread
-                         { margin-bottom:20px; }
-/* IE 7: */
-*+html #ie               {  }
-
 /* JS Classes */
 .js-display-none            { display: none; }
 .js-display-block           { display: block; }

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -7,7 +7,7 @@
 * <https://yui.github.io/yuicompressor/>.                              *
 ***********************************************************************/
 
-body                     { color:#000; background:#f9f9f9; margin:0; padding:0; font-family:verdana,arial,sans-serif; font-size:100.01%; }
+body                     { color:#000; background:#f9f9f9; margin:0; padding:0; font-family:verdana,arial,sans-serif; font-size:1em; }
 h1                       { margin-top:0; font-size:1.25em; font-weight:bold; }
 h2                       { margin-top:20px; font-size:1.25em; font-weight:bold; }
 p                        { margin-top:0; }

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -1,4 +1,4 @@
-body{color:#000;background:#f9f9f9;margin:0;padding:0;font-family:verdana,arial,sans-serif;font-size:100.01%}
+body{color:#000;background:#f9f9f9;margin:0;padding:0;font-family:verdana,arial,sans-serif;font-size:1em}
 h1{margin-top:0;font-size:1.25em;font-weight:700}
 h2{margin-top:20px;font-size:1.25em;font-weight:700}
 p{margin-top:0}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -450,15 +450,6 @@ img.right{float:right;margin:0 0 10px 10px}
 #ajax-preview-content img{max-width:100%;height:auto}
 #image-canvas{position:absolute;top:0;left:0;width:100%;height:100%;background:url(images/canvas_bg.png);z-index:20}
 #image-canvas img{display:block;margin:2em auto 0;border:1px solid #000;z-index:30;max-width:90%}
-#ie ul.reply{width:100%}
-#ie ul.reply ul{background:none}
-#ie ul.thread li{height:100%}
-* html #ie ul.thread{margin-left:-18px}
-* html #ie ul.thread li{text-indent:0}
-* html #ie #usermenu li{margin-left:5px;padding-left:5px;background:none}
-* html #ie #subnav #subnav-2{padding-top:.4em}
-* html #ie #footermenu li{margin-left:5px;padding-left:5px;background:none}
-* html #ie div.complete-thread{margin-bottom:20px}
 .js-display-none{display:none}
 .js-display-block{display:block}
 .js-visibility-hidden{visibility:hidden}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -1,4 +1,4 @@
-body{color:#000;background:#f9f9f9;margin:0;padding:0;font-family:verdana,arial,sans-serif;font-size:1em}
+body{color:#000;background:#f9f9f9;margin:0;padding:0;font-family:verdana,arial,sans-serif;font-size:1em;display:flex;flex-direction:column;min-height:100vh}
 h1{margin-top:0;font-size:1.25em;font-weight:700}
 h2{margin-top:20px;font-size:1.25em;font-weight:700}
 p{margin-top:0}
@@ -60,7 +60,7 @@ img.show-sidebar{background:url(images/bg_sprite_2.png) no-repeat 0 -22px}
 a.rss{background:url(images/bg_sprite_1.png) no-repeat 3px -1048px}
 p.right a.rss{padding-left:15px}
 input.small,select.small{font-family:verdana,arial,sans-serif;font-size:.82em}
-#content{margin:0;padding:20px;min-height:200px;background:#fff}
+#content{margin:0;padding:20px;min-height:200px;background:#fff;flex:1}
 #content p,#content ul,#content td{font-size:.82em;line-height:1.5em;max-width:60em}
 #content li,#content ul ul{font-size:1em}
 #content .xsmall{font-size:.69em;line-height:1.19em;color:gray;font-weight:400}


### PR DESCRIPTION
Replace the `div` elements for page header, main navigation, the content section and the footer to `header`, `nav`, `main` and `footer`. Additionally define the `body` as a flexbox to make the `footer` stuck on the bottom of the browser viewport in every case.

Last but not least this PR removes the CSS-fixes for Internet Explorers 6 and 7. It's time to forget that these browsers ever existed. 