### PR TITLE
Stronger restriction of the number of inactivity messages

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -192,7 +192,7 @@ function handleInactiveUsers() {
 	}
 	
 	// notify inactive users; restrict the number of users to 20
-	$result = mysqli_query($connid, "SELECT `user_id`, `user_name`, `user_email` FROM `".$db_settings['userdata_table']."` WHERE `user_lock` = 0 AND `user_type` = 0 AND `inactivity_notification` = FALSE AND (`last_login` - (NOW() - INTERVAL ". intval($settings['notify_inactive_users']) ." YEAR)) < 0 ORDER BY `last_login` ASC LIMIT 20;");
+	$result = mysqli_query($connid, "SELECT `user_id`, `user_name`, `user_email` FROM `".$db_settings['userdata_table']."` WHERE `user_lock` = 0 AND `user_type` = 0 AND `inactivity_notification` = FALSE AND (`last_login` - (NOW() - INTERVAL ". intval($settings['notify_inactive_users']) ." YEAR)) < 0 ORDER BY `last_login` ASC LIMIT 5;");
 	if (!$result)
 		return; // daily action no need to raise an error message
 	


### PR DESCRIPTION
The condition defines the number of users, that are selected for sending the inactivity messages during one run of the daily actions. Unlimited sending of e-mails can lead to a temporary grey- or blacklisting of the forum domain. Restricting the number of users and e-mails makes it less probable to get grey- or blacklisted.