### PR TITLE
Rework of the page header

### DIFF
--- a/themes/default/main.tpl
+++ b/themes/default/main.tpl
@@ -72,7 +72,9 @@
 {foreach $menu as $item}<li><a href="index.php?mode=page&amp;id={$item.id}">{$item.linkname}</a></li>{/foreach}
 {/if}
 </ul>
-<form id="topsearch" action="index.php" method="get" title="{#search_title#}" accept-charset="{#charset#}"><div><input type="hidden" name="mode" value="search" /><label for="search-input">{#search_marking#}</label>&nbsp;<input id="search-input" type="text" name="search" value="{#search_default_value#}" /><!--&nbsp;<input type="image" src="templates/{$settings.template}/images/submit.png" alt="[&raquo;]" />--></div></form></div>
+<form id="topsearch" action="index.php" method="get" title="{#search_title#}" accept-charset="{#charset#}">
+<input type="hidden" name="mode" value="search" />
+<div><label for="search-input">{#search_marking#}</label>&nbsp;<input id="search-input" type="search" name="search" />&nbsp;<input type="submit" value="{#go#}" /></div></form></div>
 </header>
 
 <nav id="subnav">

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -35,7 +35,7 @@ img.show-sidebar         { background:url(images/bg_sprite_2.png) no-repeat 0 -2
 
 #top                     { margin:0; padding:0; background:rgb(210, 222, 236); background: linear-gradient(to bottom, rgb(210, 222, 236) 0, rgb(237, 242, 245) 2.5em, rgb(237, 242, 245) 100%); }
 
-#logo                    { margin:0; padding:7px 0 7px 20px; float:left; }
+#logo                    { margin:0; padding:7px 20px 0; }
 #logo .home              { margin:0 0 0.3em 0; padding:0; font-size:0.69em; }
 #logo h1                 { margin:0; padding:0; font-size:1.75em; }
 #logo h1 a               { color:#000080; text-decoration:none; }
@@ -43,7 +43,7 @@ img.show-sidebar         { background:url(images/bg_sprite_2.png) no-repeat 0 -2
 #logo h1 a:hover         { color:#0000aa; text-decoration:none; }
 #logo .index             { margin:0; padding:0; font-size:0.82em; }
 
-#nav                     { margin:0; padding:7px 20px 7px 0; text-align:right; }
+#nav                     { margin:0; padding:7px 20px; }
 
 #usermenu                { margin:0 0 1em 0; font-size:0.69em; list-style-type:none; }
 #usermenu li             { display:inline; margin-left:5px; }

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -39,6 +39,7 @@ img.show-sidebar         { background:url(images/bg_sprite_2.png) no-repeat 0 -2
 #logo .home              { margin:0 0 0.3em 0; padding:0; font-size:0.69em; }
 #logo h1                 { margin:0; padding:0; font-size:1.75em; }
 #logo h1 a               { color:#000080; text-decoration:none; }
+#logo h1 a:focus,
 #logo h1 a:hover         { color:#0000aa; text-decoration:none; }
 #logo .index             { margin:0; padding:0; font-size:0.82em; }
 

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -52,12 +52,8 @@ img.show-sidebar         { background:url(images/bg_sprite_2.png) no-repeat 0 -2
                          { content: ""; }
 #usermenu li a           { padding-left: 4px; }
 
-#topsearch               { display:inline; }
 #topsearch div           { display:inline; font-size:0.82em; }
-#topsearch label         { display:none; }
-#topsearch #search-input { font-family:verdana,arial,sans-serif; font-size:0.82em; width:14em; color:#808080; }
-#topsearch #search-input:focus
-                         { color:#000; }
+#topsearch #search-input { font-family:verdana,arial,sans-serif; width:14em; }
 
 #subnav                  { clear:both; margin:0; padding:0; height:1.8em; color:#000000; background:#f9f9f9; border-top:1px solid #bacbdf; border-bottom:1px solid #bacbdf; line-height:1.8em; }
 #subnav #subnav-1        { font-size:0.82em; margin:0; padding:0 0 0 20px; float:left; }

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -199,11 +199,11 @@ blockquote code          { font-family:"courier new",courier; color:#6f6f6f; }
 .posting-footer a.edit   { padding-left:16px; background:url(images/bg_sprite_3.png) no-repeat 0 2px; }
 .posting-footer a.delete { padding-left:13px; background:url(images/bg_sprite_3.png) no-repeat 0 -47px; }
 .posting-footer a.go-to-top-link
-						 { padding-left: 16px; background: url(images/arrow_up.png) no-repeat 0 0 / auto 90%; }
+                         { padding-left: 16px; background: url(images/arrow_up.png) no-repeat 0 0 / auto 90%; }
 .posting-footer a.add-bookmark
-						 { padding-left:14px; background:url(images/bg_sprite_3.png) no-repeat 0 -97px; }
+                         { padding-left:14px; background:url(images/bg_sprite_3.png) no-repeat 0 -97px; }
 .posting-footer a.delete-bookmark
-						 { padding-left:14px; background:url(images/bg_sprite_3.png) no-repeat 0 -147px; }
+                         { padding-left:14px; background:url(images/bg_sprite_3.png) no-repeat 0 -147px; }
 .posting-footer a.move   { padding-left:13px; background:url(images/bg_sprite_4.png) no-repeat 0 2px; }
 .posting-footer a.report { padding-left:14px; background:url(images/bg_sprite_4.png) no-repeat 0 -48px; }
 .posting-footer a.lock   { padding-left:16px; background:url(images/bg_sprite_4.png) no-repeat 0 -99px; }
@@ -467,9 +467,9 @@ ul.pagination-index-table
                          { margin: 0; padding: 0 5px; font-size: 0.69em; line-height: 1.7em; background: #d2ddea url("images/bg_gradient_x.png") repeat-x scroll 0 -150px; }
 .additional-admin-info p { font-size: 0.69em; line-height: 1.5em; margin: 0; padding: 5px; }
 #admin-info-install_script_exists h3
-						 { color: red; }
+                         { color: red; }
 #admin-info-install_script_exists h3::before 
-						 { content: url("images/caution.png"); padding-right: 5px; }
+                         { content: url("images/caution.png"); padding-right: 5px; }
 
 .adminmenu               { list-style-type:none; padding-left:0; margin-left:0; font-size:0.82em; line-height:1.7em !important; }
 .adminmenu li            {  }
@@ -677,7 +677,7 @@ img.right                { float:right; margin:0 0 10px 10px; }
 .js-display-fold img.avatar { width: 1.6em; height: 1.6em; }
 
 /* Admin Warning */
-div.warning 			 { border: 5px solid red; padding: 15px; font-size:1.3em; }
+div.warning              { border: 5px solid red; padding: 15px; font-size:1.3em; }
 
 /* Honey pots */
 form p.hp { display: none; }

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -51,7 +51,8 @@ img.show-sidebar         { background:url(images/bg_sprite_2.png) no-repeat 0 -2
 #usermenu li:before      { content: "|"; }
 #usermenu li:first-child:before
                          { content: ""; }
-#usermenu li a           { padding-left: 4px; }
+#usermenu li:not(:first-child) a
+                         { padding-left: 4px; }
 
 #topsearch div           { display:inline; font-size:0.82em; }
 #topsearch #search-input { font-family:verdana,arial,sans-serif; width:14em; }

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -37,7 +37,7 @@ img.show-sidebar         { background:url(images/bg_sprite_2.png) no-repeat 0 -2
 
 #logo                    { margin:0; padding:7px 20px 0; }
 #logo .home              { margin:0 0 0.3em 0; padding:0; font-size:0.69em; }
-#logo h1                 { margin:0; padding:0; font-size:1.75em; }
+#logo h1                 { margin:0; padding:0; font-size:1.6em; }
 #logo h1 a               { color:#000080; text-decoration:none; }
 #logo h1 a:focus,
 #logo h1 a:hover         { color:#0000aa; text-decoration:none; }

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -45,7 +45,7 @@ img.show-sidebar         { background:url(images/bg_sprite_2.png) no-repeat 0 -2
 
 #nav                     { margin:0; padding:7px 20px; }
 
-#usermenu                { margin:0 0 1em 0; font-size:0.69em; list-style-type:none; }
+#usermenu                { margin:0 0 0.75em 0; padding:0; font-size:0.69em; list-style-type:none; }
 #usermenu li             { display:inline; margin-left:5px; }
 #usermenu li:first-child { margin-left:0; padding-left:0; }
 #usermenu li:before      { content: "|"; }

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -33,7 +33,7 @@ img.previous:hover       { background:url(images/bg_sprite_2.png) no-repeat -6px
 img.hide-sidebar         { background:url(images/bg_sprite_2.png) no-repeat -9px -22px; }
 img.show-sidebar         { background:url(images/bg_sprite_2.png) no-repeat 0 -22px; }
 
-#top                     { margin:0; padding:0; height:4.4em; color:#000; background:#d2ddea url(images/bg_gradient_x.png) repeat-x 0 0; }
+#top                     { margin:0; padding:0; background:rgb(210, 222, 236); background: linear-gradient(to bottom, rgb(210, 222, 236) 0, rgb(237, 242, 245) 2.5em, rgb(237, 242, 245) 100%); }
 
 #logo                    { margin:0; padding:7px 0 7px 20px; float:left; }
 #logo .home              { margin:0 0 0.3em 0; padding:0; font-size:0.69em; }

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -680,4 +680,10 @@ img.right                { float:right; margin:0 0 10px 10px; }
 div.warning 			 { border: 5px solid red; padding: 15px; font-size:1.3em; }
 
 /* Honey pots */
-form p.hp					{ display: none; }
+form p.hp { display: none; }
+
+@media screen and (min-width: 45em) {
+  #top { display: flex; justify-content: space-between; }
+  #logo { padding: 7px 5px 7px 20px; }
+  #nav { padding-left: 5px; text-align: right; }
+}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -455,3 +455,8 @@ img.right{float:right;margin:0 0 10px 10px}
 .js-display-fold .wrapper,.js-display-fold #sidebarcontent{display:none}
 .js-display-fold img.avatar{width:1.6em;height:1.6em}
 form p.hp{display: none}
+@media screen and (min-width: 48em) {
+	#top {display:flex;justify-content:space-between}
+	#logo {padding:7px 5px 7px 20px}
+	#nav {padding-left:5px;text-align:right}
+}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -25,8 +25,8 @@ img.show-sidebar{background:url(images/bg_sprite_2.png) no-repeat 0 -22px}
 #logo h1 a{color:navy;text-decoration:none}
 #logo h1 a:focus,#logo h1 a:hover{color:#00a;text-decoration:none}
 #logo .index{margin:0;padding:0;font-size:.82em}
-#usermenu{margin:0 0 1em;font-size:.69em;list-style-type:none}
 #nav{margin:0;padding:7px 20px}
+#usermenu{margin:0 0 0.75em;padding:0;font-size:.69em;list-style-type:none}
 #usermenu li{display:inline;margin-left:5px}
 #usermenu li:first-child{margin-left:0;padding-left:0}
 #usermenu li:before{content:"|"}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -32,7 +32,6 @@ img.show-sidebar{background:url(images/bg_sprite_2.png) no-repeat 0 -22px}
 #usermenu li:before{content:"|"}
 #usermenu li:first-child:before{content:""}
 #usermenu li a{padding-left:4px}
-#topsearch{display:inline}
 #topsearch div{display:inline;font-size:.82em}
 #topsearch #search-input{font-family:verdana,arial,sans-serif;width:14em}
 #subnav{clear:both;margin:0;padding:0;height:1.8em;color:#000;background:#f9f9f9;border-top:1px solid #bacbdf;border-bottom:1px solid #bacbdf;line-height:1.8em}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -21,7 +21,7 @@ img.show-sidebar{background:url(images/bg_sprite_2.png) no-repeat 0 -22px}
 #top{margin:0;padding:0;background:#d2ddea;background: linear-gradient(to bottom, rgb(210, 222, 236) 0, rgb(237, 242, 245) 2.5em, rgb(237, 242, 245) 100%)}
 #logo{margin:0;padding:7px 20px 0}
 #logo .home{margin:0 0 .3em;padding:0;font-size:.69em}
-#logo h1{margin:0;padding:0;font-size:1.75em}
+#logo h1{margin:0;padding:0;font-size:1.6em}
 #logo h1 a{color:navy;text-decoration:none}
 #logo h1 a:focus,#logo h1 a:hover{color:#00a;text-decoration:none}
 #logo .index{margin:0;padding:0;font-size:.82em}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -34,9 +34,7 @@ img.show-sidebar{background:url(images/bg_sprite_2.png) no-repeat 0 -22px}
 #usermenu li a{padding-left:4px}
 #topsearch{display:inline}
 #topsearch div{display:inline;font-size:.82em}
-#topsearch label{display:none}
-#topsearch #search-input{font-family:verdana,arial,sans-serif;font-size:.82em;width:14em;color:gray}
-#topsearch #search-input:focus{color:#000}
+#topsearch #search-input{font-family:verdana,arial,sans-serif;width:14em}
 #subnav{clear:both;margin:0;padding:0;height:1.8em;color:#000;background:#f9f9f9;border-top:1px solid #bacbdf;border-bottom:1px solid #bacbdf;line-height:1.8em}
 #subnav #subnav-1{font-size:.82em;margin:0;padding:0 0 0 20px;float:left}
 #subnav #subnav-2{font-size:.82em;margin:0;padding:0 20px 0 0;text-align:right}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -18,15 +18,15 @@ img.previous{background:url(images/bg_sprite_2.png) no-repeat 0 0}
 img.previous:hover{background:url(images/bg_sprite_2.png) no-repeat -6px 0}
 img.hide-sidebar{background:url(images/bg_sprite_2.png) no-repeat -9px -22px}
 img.show-sidebar{background:url(images/bg_sprite_2.png) no-repeat 0 -22px}
-#logo{margin:0;padding:7px 0 7px 20px;float:left}
 #top{margin:0;padding:0;background:#d2ddea;background: linear-gradient(to bottom, rgb(210, 222, 236) 0, rgb(237, 242, 245) 2.5em, rgb(237, 242, 245) 100%)}
+#logo{margin:0;padding:7px 20px 0}
 #logo .home{margin:0 0 .3em;padding:0;font-size:.69em}
 #logo h1{margin:0;padding:0;font-size:1.75em}
 #logo h1 a{color:navy;text-decoration:none}
 #logo h1 a:focus,#logo h1 a:hover{color:#00a;text-decoration:none}
 #logo .index{margin:0;padding:0;font-size:.82em}
-#nav{margin:0;padding:7px 20px 7px 0;text-align:right}
 #usermenu{margin:0 0 1em;font-size:.69em;list-style-type:none}
+#nav{margin:0;padding:7px 20px}
 #usermenu li{display:inline;margin-left:5px}
 #usermenu li:first-child{margin-left:0;padding-left:0}
 #usermenu li:before{content:"|"}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -31,7 +31,7 @@ img.show-sidebar{background:url(images/bg_sprite_2.png) no-repeat 0 -22px}
 #usermenu li:first-child{margin-left:0;padding-left:0}
 #usermenu li:before{content:"|"}
 #usermenu li:first-child:before{content:""}
-#usermenu li a{padding-left:4px}
+#usermenu li:not(:first-child) a{padding-left:4px}
 #topsearch div{display:inline;font-size:.82em}
 #topsearch #search-input{font-family:verdana,arial,sans-serif;width:14em}
 #subnav{clear:both;margin:0;padding:0;height:1.8em;color:#000;background:#f9f9f9;border-top:1px solid #bacbdf;border-bottom:1px solid #bacbdf;line-height:1.8em}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -18,8 +18,8 @@ img.previous{background:url(images/bg_sprite_2.png) no-repeat 0 0}
 img.previous:hover{background:url(images/bg_sprite_2.png) no-repeat -6px 0}
 img.hide-sidebar{background:url(images/bg_sprite_2.png) no-repeat -9px -22px}
 img.show-sidebar{background:url(images/bg_sprite_2.png) no-repeat 0 -22px}
-#top{margin:0;padding:0;height:4.4em;color:#000;background:#d2ddea url(images/bg_gradient_x.png) repeat-x 0 0}
 #logo{margin:0;padding:7px 0 7px 20px;float:left}
+#top{margin:0;padding:0;background:#d2ddea;background: linear-gradient(to bottom, rgb(210, 222, 236) 0, rgb(237, 242, 245) 2.5em, rgb(237, 242, 245) 100%)}
 #logo .home{margin:0 0 .3em;padding:0;font-size:.69em}
 #logo h1{margin:0;padding:0;font-size:1.75em}
 #logo h1 a{color:navy;text-decoration:none}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -23,7 +23,7 @@ img.show-sidebar{background:url(images/bg_sprite_2.png) no-repeat 0 -22px}
 #logo .home{margin:0 0 .3em;padding:0;font-size:.69em}
 #logo h1{margin:0;padding:0;font-size:1.75em}
 #logo h1 a{color:navy;text-decoration:none}
-#logo h1 a:hover{color:#00a;text-decoration:none}
+#logo h1 a:focus,#logo h1 a:hover{color:#00a;text-decoration:none}
 #logo .index{margin:0;padding:0;font-size:.82em}
 #nav{margin:0;padding:7px 20px 7px 0;text-align:right}
 #usermenu{margin:0 0 1em;font-size:.69em;list-style-type:none}


### PR DESCRIPTION
Because of the recent changes (doctype from XHTML 1.0 to HTML (5)) a bug appeared. It caused the user menu to disappeared in some cases because of the fixed height of the header. The menu slips out of the visible area and is unreachable on narrow viewports.

I reworked the header with using a media query that makes it possible to put the elements one below the other on narrow viewports and to put it side by side on wider viewports. So there is no big difference on great screens with a large browser viewport. On narrow viewports, where the bug appears, the elements are stapled vertically with no limit of the headers height. So the elements are visible all time. 

See also #607 