### PR TITLE
Ensure the position of the signature below all entry content

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -225,7 +225,11 @@ blockquote code          { font-family:"courier new",courier; color:#6f6f6f; }
 .thread-posting .header  { background:#f5f5f5; margin:0 0 0 0; padding:0 0 5px 10px; }
 .thread-posting .header img.avatar
                          { position:relative; margin:0 0 20px 20px; padding:5px; background:#f5f5f5; float:right; }
-.thread-posting .body    { margin:0; padding:10px 10px 10px 10px; }
+.thread-posting .body    { margin:0; padding:10px; }
+.thread-posting .signature
+                         { margin: 0; padding: 10px; }
+#content .thread-posting p.tags
+                         { margin: 0; padding: 10px; }
 .thread-posting .author  { margin:1px 0 0 0; font-style:italic; }
 .thread-posting .posting-footer
                          { margin:10px; }
@@ -240,8 +244,9 @@ blockquote code          { font-family:"courier new",courier; color:#6f6f6f; }
 .op-link,
 .op-link a               { font-size:0.9em; color:#808080; }
 
+#content .body           { overflow: hidden; }
 #content p.tags          { margin:20px 0 0 0; padding:0; color:#808080; font-size:0.69em; line-height:1.42em; }
-#content p.signature     { margin:10px 0 0 0; padding:0; color:#808080; font-weight:normal; font-size:0.69em; line-height:1.42em; }
+#content .signature p    { margin:10px 0 0 0; padding:0; color:#808080; font-weight:normal; font-size:0.69em; line-height:1.42em; }
 
 h2.postingform           { margin:0 0 20px 0; }
 p.reply-to               { margin:0 0 20px 0; }

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -159,6 +159,8 @@ blockquote code{font-family:"courier new",courier;color:#6f6f6f}
 .thread-posting .header{background:#f5f5f5;margin:0;padding:0 0 5px 10px}
 .thread-posting .header img.avatar{position:relative;margin:0 0 20px 20px;padding:5px;background:#f5f5f5;float:right}
 .thread-posting .body{margin:0;padding:10px}
+.thread-posting .signature{margin:0;padding:10px}
+#content .thread-posting p.tags{margin:0;padding:10px}
 .thread-posting .author{margin:1px 0 0;font-style:italic}
 .thread-posting .posting-footer{margin:10px}
 .hide-posting{position:absolute;top:0;left:-10px}
@@ -167,8 +169,9 @@ blockquote code{font-family:"courier new",courier;color:#6f6f6f}
 .deep-reply-wrapper{margin:0 0 0 10px;padding:0;list-style-type:none}
 .very-deep-reply-wrapper{margin:0;padding:0;list-style-type:none}
 .op-link,.op-link a{font-size:.9em;color:gray}
+#content .body{overflow:hidden}
 #content p.tags{margin:20px 0 0;padding:0;color:gray;font-size:.69em;line-height:1.42em}
-#content p.signature{margin:10px 0 0;padding:0;color:gray;font-weight:400;font-size:.69em;line-height:1.42em}
+#content .signature p{margin:10px 0 0;padding:0;color:gray;font-weight:400;font-size:.69em;line-height:1.42em}
 h2.postingform{margin:0 0 20px}
 p.reply-to{margin:0 0 20px}
 div.complete-thread{margin-bottom:30px}

--- a/themes/default/subtemplates/entry.inc.tpl
+++ b/themes/default/subtemplates/entry.inc.tpl
@@ -38,15 +38,15 @@
 {else}
 <p>{#no_text#}</p>
 {/if}
+</div>
 {if $signature}
-<p class="signature">--<br />
-{$signature}</p>
+<div class="signature"><p>--<br />
+{$signature}</p></div>
 {/if}
 {if $tags}
 <p class="tags">{#tags_marking#}<br />
 {foreach name="tags" from=$tags item=tag}<a href="index.php?mode=search&amp;search={$tag.escaped}&amp;method=tags">{$tag.display}</a>{if !$smarty.foreach.tags.last}, {/if}{/foreach}</p>
 {/if}
-</div>
 <div class="posting-footer">
 <div class="reply">{if $locked==0}<a class="stronglink" href="index.php?mode=posting&amp;id={$id}&amp;back=entry" title="{#reply_link_title#}">{#reply_link#}</a>{else}<span class="locked">{#posting_locked#}</span>{/if}</div>
 <div class="info">

--- a/themes/default/subtemplates/posting.inc.tpl
+++ b/themes/default/subtemplates/posting.inc.tpl
@@ -36,13 +36,18 @@
 <h3 class="preview">{#preview_headline#}</h3>
 <div class="preview">
 <div class="posting">
+<div class="header">
 <h1 class="postingheadline">{$preview_subject}{if $category_name} <span class="category">({$category_name})</span>{/if}</h1>
 <p class="author">{if $preview_location}{#posted_by_location#|replace:"[name]":$preview_name|replace:"[email_hp]":$email_hp|replace:"[location]":$preview_location|replace:"[time]":$preview_formated_time}{else}{#posted_by#|replace:"[name]":$preview_name|replace:"[email_hp]":$email_hp|replace:"[time]":$preview_formated_time}{/if}</p>
-{if $preview_text}{$preview_text}{else}<p>{#no_text#}</p>{/if}
+</div>
+<div class=""wrapper">
+<div class="body">{if $preview_text}{$preview_text}{else}<p>{#no_text#}</p>{/if}</div>
 {if $preview_signature && $show_signature==1}
-<p class="signature">---<br />
+<div class="signature"><p>---<br />
 {$preview_signature}</p>
+</div>
 {/if}
+</div>
 </div>
 </div>
 {/if}

--- a/themes/default/subtemplates/thread.inc.tpl
+++ b/themes/default/subtemplates/thread.inc.tpl
@@ -50,15 +50,15 @@
 {else}
 <p>{#no_text#}</p>
 {/if}
+</div>
 {if $data.$element.signature}
-<p class="signature">--<br />
-{$data.$element.signature}</p>
+<div class="signature"><p>--<br />
+{$data.$element.signature}</p></div>
 {/if}
 {if $data.$element.tags}
 <p class="tags">{#tags_marking#}<br />
 {foreach name="tags" from=$data.$element.tags item=tag}<a href="index.php?mode=search&amp;search={$tag.escaped}&amp;method=tags">{$tag.display}</a>{if !$smarty.foreach.tags.last}, {/if}{/foreach}</p>
 {/if}
-</div>
 <div class="posting-footer">
 <div class="reply">{if $data.$element.locked==0}<a class="stronglink" href="index.php?mode=posting&amp;id={$data.$element.id}&amp;back=thread" title="{#reply_link_title#}">{#reply_link#}</a>{else}<span class="locked">{#posting_locked#}</span>{/if}</div>
 <div class="info">&nbsp;

--- a/themes/default/subtemplates/thread_linear.inc.tpl
+++ b/themes/default/subtemplates/thread_linear.inc.tpl
@@ -50,15 +50,15 @@
 {else}
 <p>{#no_text#}</p>
 {/if}
+</div>
 {if $element.signature}
-<p class="signature">--<br />
-{$element.signature}</p>
+<div class="signature"><p>--<br />
+{$element.signature}</p></div>
 {/if}
 {if $element.tags}
 <p class="tags">{#tags_marking#}<br />
 {foreach name="tags" from=$element.tags item=tag}<a href="index.php?mode=search&amp;search={$tag.escaped}&amp;method=tags">{$tag.display}</a>{if !$smarty.foreach.tags.last}, {/if}{/foreach}</p>
 {/if}
-</div>
 <div class="posting-footer">
 <div class="reply">{if $element.locked==0}<a class="stronglink" href="index.php?mode=posting&amp;id={$element.id}&amp;back=thread" title="{#reply_link_title#}">{#reply_link#}</a>{else}<span class="locked">{#posting_locked#}</span>{/if}</div>
 <div class="info">&nbsp;


### PR DESCRIPTION
When inserting floated images into an entry, the signature, which was a part of the entry's HTML-container until now, floated with the entries own content around the image when the content was not enough to float around the image itself. The current change puts the signature into a separate container, that *follwos* the entries container and defines a floating context for the entry container.

That way the signature will be displayed below the complete entry in every case.