### PR TITLE
Empty search box

### DIFF
--- a/includes/search.inc.php
+++ b/includes/search.inc.php
@@ -49,6 +49,7 @@ if (isset($_GET['search'])) {
 		}
 		$search_array = $stripped_search_array;
 	}
+	$search_string_array = array();
 	foreach ($search_array as $item) {
 		if (my_strpos($item, ' ', 0, CHARSET)) {
 			$item = '"' . $item . '"';


### PR DESCRIPTION
The array `$search_string_array` is not initialised, iff the search box is left empty and cased an error/warning, cf. https://mylittleforum.net/forum/index.php?id=13112