### PR TITLE
WebP support for image upload

### DIFF
--- a/includes/admin.inc.php
+++ b/includes/admin.inc.php
@@ -954,7 +954,7 @@ if (isset($_SESSION[$settings['session_prefix'].'user_id']) && isset($_SESSION[$
 		$browse_images = (isset($_GET['browse_images']) && $_GET['browse_images'] > 0) ? intval($_GET['browse_images']) : 1;
 		$handle = opendir($uploaded_images_path);
 		while ($file = readdir($handle)) {
-			if (preg_match('/\.(gif|png|jpg|svg)$/i', $file)) {
+			if (preg_match('/\.(gif|png|jpg|svg|webp)$/i', $file)) {
 				$images[] = $file;
 			}
 		}

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -1559,24 +1559,25 @@ function resize_image($uploaded_file, $file, $new_width, $new_height, $compressi
    }
 
   $image_info = getimagesize($uploaded_file);
-  if(!is_array($image_info) || $image_info[2] != 1 && $image_info[2] != 2 && $image_info[2] != 3) $error = true;
+  $imageMIME = mime_content_type($uploaded_file);
+  if(!is_array($image_info) || !in_array($imageMIME, ['image/gif', 'image/jpeg', 'image/png'])) $error = true;
   if(empty($error))
   {
-  if($image_info[2]==1) // GIF
+  if($imageMIME=='image/gif') // GIF
    {
     $current_image = @imagecreatefromgif($uploaded_file) or $error = true;
     if(empty($error)) $new_image = @imagecreate($new_width,$new_height) or $error = true;
     if(empty($error)) @imagecopyresampled($new_image,$current_image,0,0,0,0,$new_width,$new_height,$image_info[0],$image_info[1]) or $error=true;
     if(empty($error)) @imagegif($new_image, $file) or $error = true;
    }
-  elseif($image_info[2]==2) // JPG
+  elseif($imageMIME=='image/jpeg') // JPG
    {
     $current_image = @imagecreatefromjpeg($uploaded_file) or $error = true;
     if(empty($error)) $new_image=@imagecreatetruecolor($new_width,$new_height) or $error = true;
     if(empty($error)) @imagecopyresampled($new_image,$current_image,0,0,0,0,$new_width,$new_height,$image_info[0],$image_info[1]) or $error = true;
     if(empty($error)) @imagejpeg($new_image, $file, $compression) or $error = true;
    }
-  elseif($image_info[2]==3) // PNG
+  elseif($imageMIME=='image/png') // PNG
    {
     $current_image=imagecreatefrompng($uploaded_file) or $error = true;
     if(empty($error)) $new_image=imagecreatetruecolor($new_width,$new_height) or $error = true;

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -1560,7 +1560,7 @@ function resize_image($uploaded_file, $file, $new_width, $new_height, $compressi
 
   $image_info = getimagesize($uploaded_file);
   $imageMIME = mime_content_type($uploaded_file);
-  if(!is_array($image_info) || !in_array($imageMIME, ['image/gif', 'image/jpeg', 'image/png'])) $error = true;
+  if(!is_array($image_info) || !in_array($imageMIME, ['image/gif', 'image/jpeg', 'image/png', 'image/webp'])) $error = true;
   if(empty($error))
   {
   if($imageMIME=='image/gif') // GIF
@@ -1583,6 +1583,13 @@ function resize_image($uploaded_file, $file, $new_width, $new_height, $compressi
     if(empty($error)) $new_image=imagecreatetruecolor($new_width,$new_height) or $error = true;
     if(empty($error)) imagecopyresampled($new_image,$current_image,0,0,0,0,$new_width,$new_height,$image_info[0],$image_info[1]) or $error = true;
     if(empty($error)) imagepng($new_image, $file) or $error = $true;
+   }
+  elseif($imageMIME=='image/webp') // WebP
+   {
+    $current_image=imagecreatefromwebp($uploaded_file) or $error = true;
+    if(empty($error)) $new_image=imagecreatetruecolor($new_width,$new_height) or $error = true;
+    if(empty($error)) imagecopyresampled($new_image,$current_image,0,0,0,0,$new_width,$new_height,$image_info[0],$image_info[1]) or $error = true;
+    if(empty($error)) imagewebp($new_image, $file) or $error = $true;
    }
   }
   if(empty($error)) return true;

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -109,7 +109,7 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 			$smarty->assign('delete', htmlspecialchars($_REQUEST['delete']));
 			if (isset($_REQUEST['current'])) $smarty->assign('current', intval($_REQUEST['current']));
 		} else {
-			if (preg_match('/^([a-z0-9]+)\.(gif|jpg|png)$/', $_REQUEST['delete']) && file_exists($uploaded_images_path.$_REQUEST['delete'])) {
+			if (preg_match('/^([a-z0-9]+)\.(gif|jpg|png|webp)$/', $_REQUEST['delete']) && file_exists($uploaded_images_path.$_REQUEST['delete'])) {
 				@chmod($uploaded_images_path.$_REQUEST['delete'], 0777);
 				@unlink($uploaded_images_path.$_REQUEST['delete']);
 			}

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -15,7 +15,7 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 		$user_id = (isset($_SESSION[$settings['session_prefix'].'user_id'])) ? intval($_SESSION[$settings['session_prefix'].'user_id']) : NULL;
 		$image_info = getimagesize($_FILES['probe']['tmp_name']);
 		$imageMIME = mime_content_type($_FILES['probe']['tmp_name']);
-		if (!is_array($image_info) || !in_array($imageMIME, ['image/gif', 'image/jpeg', 'image/png']))
+		if (!is_array($image_info) || !in_array($imageMIME, ['image/gif', 'image/jpeg', 'image/png', 'image/webp']))
 			$errors[] = 'invalid_file_format';
 
 		if (empty($errors)) {
@@ -74,6 +74,9 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 				break;
 				case 'image/png':
 					$filename .= '.png';
+				break;
+				case 'image/webp':
+					$filename .= '.webp';
 				break;
 			}
 			if (isset($img_tmp_name)) {

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -14,7 +14,8 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 		unset($errors);
 		$user_id = (isset($_SESSION[$settings['session_prefix'].'user_id'])) ? intval($_SESSION[$settings['session_prefix'].'user_id']) : NULL;
 		$image_info = getimagesize($_FILES['probe']['tmp_name']);
-		if (!is_array($image_info) || $image_info[2] != 1 && $image_info[2] != 2 && $image_info[2] != 3)
+		$imageMIME = mime_content_type($_FILES['probe']['tmp_name']);
+		if (!is_array($image_info) || !in_array($imageMIME, ['image/gif', 'image/jpeg', 'image/png']))
 			$errors[] = 'invalid_file_format';
 
 		if (empty($errors)) {
@@ -41,7 +42,7 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 						break;
 					}
 					$file_size = @filesize($uploaded_images_path.$img_tmp_name);
-					if ($image_info[2] != 2 && $file_size > $settings['upload_max_img_size'] * 1000) break;
+					if ($imageMIME != 'image/jpeg' && $file_size > $settings['upload_max_img_size'] * 1000) break;
 					if ($file_size <= $settings['upload_max_img_size'] * 1000) break;
 				}
 				if ($file_size > $settings['upload_max_img_size'] * 1000) {
@@ -64,14 +65,14 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 
 		if (empty($errors)) {
 			$filename = gmdate("YmdHis").uniqid('');
-			switch($image_info[2]) {
-				case 1:
+			switch($imageMIME) {
+				case 'image/gif':
 					$filename .= '.gif';
 				break;
-				case 2:
+				case 'image/jpeg':
 					$filename .= '.jpg';
 				break;
-				case 3:
+				case 'image/png':
 					$filename .= '.png';
 				break;
 			}


### PR DESCRIPTION
Because of [a request in the project forum](https://mylittleforum.net/forum/index.php?id=13145) I researched the conditions for supporting WebP-images in the image-upload-feature. It was a sitting duck to adapt the existing code because creation a WebP-image works similar to the equivalent functions for GIF-, JPEG- or PNG-images. Furthermore I changed the file type detection for images because using `getimagesize` for this purpose [is not recommeded anymore](https://www.php.net/manual/en/function.getimagesize.php).

> "Do not use `getimagesize()` to check that a given file is a valid image. Use a purpose-built solution such as the [Fileinfo](https://www.php.net/manual/en/book.fileinfo.php) extension instead."

The file-type-check is now based on the MIME-type. As a side effect of this change it is *theoretically* possible to allow further file types to be uploaded.

---

I tested the functionallity in a testing instance of the forum. The upload-script accepts WebP-images generally and it also resamples to large source images with lossy compression. That way I downsized a to large source image (1384x1341px, 1.7 MB) to 1024x990px with a filesize of 123kB [^1] without any obviously visible compression artifacts, as it is common with highly compressed JPEG-images.

[^1]: The settings for uploading images in my testing instance allows images with dimensions up to 1024px and a maximal file size of 200kB.