### PR TITLE
flexbof for ham and spam buttons, ready for reuse

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -472,6 +472,11 @@ ul.pagination-index-table
 #codepicker ul a:focus,
 #codepicker ul a:hover   { background:#e0e0e0; }
 
+/* buttonbars */
+.buttonbar               { display:flex; flex-wrap:wrap; gap:0.3em; }
+.buttonbar button        { padding:0.3em; }
+
+/* admin panel */
 .additional-admin-info   { margin:0 0 1em 0; padding:0; }
 .additional-admin-info div
                          { background: #f9f9f9; border: 1px solid #bacbdf; padding: 0; }

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -322,6 +322,8 @@ ul.pagination-index-table{margin-top:20px!important;text-align:right;max-width:1
 #codepicker ul{list-style-type:none;margin:0;padding:0}
 #codepicker ul a{color:#000;display:block;text-decoration:none;padding:1px 5px}
 #codepicker ul a:focus,#codepicker ul a:hover{background:#e0e0e0}
+.buttonbar{display:flex; flex-wrap:wrap; gap:0.3em}
+.buttonbar button{padding:0.3em}
 .additional-admin-info{margin:0 0 1em 0;padding:0}
 .additional-admin-info div{background:#f9f9f9;border:1px solid #bacbdf;padding:0}
 .additional-admin-info div:not(:last-child){margin:0 0 20px 0}

--- a/themes/default/subtemplates/posting_flag_ham.inc.tpl
+++ b/themes/default/subtemplates/posting_flag_ham.inc.tpl
@@ -12,13 +12,13 @@
 		<p>{#flag_ham_warning#}</p>
 		<p><strong>{$subject}</strong> - <strong>{$name}</strong>, {$disp_time|date_format:#time_format#}</p>
 		<form action="index.php" method="post" accept-charset="{#charset#}">
-		<div>
 			<input type="hidden" name="mode" value="posting" />
 			<input type="hidden" name="id" value="{$id}" />
 			<input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />
-			<input type="submit" name="report_flag_ham_submit" value="{#report_flag_ham_submit#}" /> 
-			<input type="submit" name="flag_ham_submit" value="{#flag_ham_submit#}" />
-		</div>
+			<div class="buttonbar">
+				<button name="report_flag_ham_submit" value="{#report_flag_ham_submit#}">{#report_flag_ham_submit#}</button>
+				<button name="flag_ham_submit" value="{#flag_ham_submit#}">{#flag_ham_submit#}</button>
+			</div>
 		</form>
 	{/if}
 {/if}

--- a/themes/default/subtemplates/posting_report_spam.inc.tpl
+++ b/themes/default/subtemplates/posting_report_spam.inc.tpl
@@ -15,7 +15,6 @@
 		
 		<p><strong>{$subject}</strong> - <strong>{$name}</strong>, {$disp_time|date_format:#time_format#}</p>
 		<form action="index.php" method="post" accept-charset="{#charset#}">
-		<div>
 			<input type="hidden" name="mode" value="posting" />
 			<input type="hidden" name="id" value="{$id}" />
 			<input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />
@@ -24,10 +23,11 @@
 			{if $order}<input type="hidden" name="order" value="{$order}" />{/if}
 			{if $descasc}<input type="hidden" name="descasc" value="{$descasc}" />{/if}
 			{if $category}<input type="hidden" name="category" value="{$category}" />{/if}
-			<input type="submit" name="report_spam_delete_submit" value="{#report_spam_delete_submit#}" /> 
-			<input type="submit" name="report_spam_submit" value="{#report_spam_submit#}" /> 
-			<input type="submit" name="delete_submit" value="{#delete_only_submit#}" />
-		</div>
+			<div class="buttonbar">
+				<button name="report_spam_delete_submit" value="{#report_spam_delete_submit#}">{#report_spam_delete_submit#}</button>
+				<button name="report_spam_submit" value="{#report_spam_submit#}">{#report_spam_submit#}</button>
+				<button name="delete_submit" value="{#delete_only_submit#}">{#delete_only_submit#}</button>
+			</div>
 		</form>
 	{/if}
 {/if}


### PR DESCRIPTION
The buttons are styled inline and have no gaps inbetween. They have therefore a poor usability especially on mobile devices with small viewports. The flexbox brings customisable gaps to them. Furthermore I changed the submit buttons from `input` of type submit to `button`. That way we have more control over the content of the buttons ((styled) text, icons, …) 

To change to `button` and to classifying their parent element as `.buttonbar` makes it easy to reuse the rules for other cases. Make the buttons buttons and put the buttons into an element with the class `.buttonbar` and you are done.