### PR TITLE
Locked entries that gets classified as ham should remain locked

### DIFF
--- a/includes/posting.inc.php
+++ b/includes/posting.inc.php
@@ -1799,7 +1799,7 @@ switch ($action) {
 		break;
 	case 'flag_ham_submit':
 		if (isset($_SESSION[$settings['session_prefix'] . 'user_type']) && $_SESSION[$settings['session_prefix'] . 'user_type'] > 0 && $_POST['csrf_token'] === $_SESSION['csrf_token']) {
-			$result = mysqli_query($connid, "SELECT tid, user_id, name, email, hp, subject, location, text,
+			$result = mysqli_query($connid, "SELECT tid, user_id, name, email, hp, subject, location, text, locked,
 											" . $db_settings['akismet_rating_table'] . ".spam AS akismet_spam, spam_check_status, 
 											" . $db_settings['b8_rating_table'] . ".spam AS b8_spam, training_type 
 											 FROM " . $db_settings['forum_table'] . " 

--- a/includes/posting.inc.php
+++ b/includes/posting.inc.php
@@ -1808,7 +1808,11 @@ switch ($action) {
 											 WHERE id = " . intval($id) . " LIMIT 1") or raise_error('database_error', mysqli_error($connid));
 			$data = mysqli_fetch_array($result);
 			if (mysqli_num_rows($result) == 1) {
-				@mysqli_query($connid, "UPDATE " . $db_settings['forum_table'] . " SET time = time, last_reply = last_reply, edited = edited, locked = 0 WHERE id = " . intval($id)) or raise_error('database_error', mysqli_error($connid));
+				if ($data['locked'] == 1 && $data['spam_check_status'] == 0 && $data['training_type'] == 0) {
+					// do nothing and leave the entry locked
+				} else {
+					@mysqli_query($connid, "UPDATE " . $db_settings['forum_table'] . " SET time = time, last_reply = last_reply, edited = edited, locked = 0 WHERE id = " . intval($id)) or raise_error('database_error', mysqli_error($connid));
+				}
 				// Flag HAM in rating tables
 				@mysqli_query($connid, "REPLACE INTO " . $db_settings['akismet_rating_table'] . " (`eid`, `spam`, `spam_check_status`) VALUES (" . intval($id) . ", 0, 1)") or raise_error('database_error', mysqli_error($connid));
 				@mysqli_query($connid, "REPLACE INTO " . $db_settings['b8_rating_table'] . " (`eid`, `spam`, `training_type`) VALUES (" . intval($id) . ", 0, 1)") or raise_error('database_error', mysqli_error($connid));


### PR DESCRIPTION
This affects only cases, when the entry was not classified directly before the classification, in example old entries that should be classified to train the Bayes filter. All other entries, in example entries, that was classified as spam before but are ham or unclassified but also unlocked ham entries, *are not affected* by this change.

This fixes #615