### PR TITLE
Fix: change charset of column user_email to utf8 …

### DIFF
--- a/update/update_2.4.19.1-2.5.php
+++ b/update/update_2.4.19.1-2.5.php
@@ -467,6 +467,18 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19.1',
 			$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 		}
 	}
+	$rObsoleteIndexes = mysqli_query($connid, "SELECT DISTINCT INDEX_NAME AS obsolete_key
+	FROM information_schema.STATISTICS 
+	WHERE TABLE_SCHEMA LIKE '". $db_settings['database'] ."' AND
+	TABLE_NAME LIKE '" . $db_settings['userdata_table'] ."' AND 
+	INDEX_NAME LIKE 'user_%';");
+	if (mysqli_num_rows($rObsoleteIndexes) > 0) {
+		while ($row  = mysqli_fetch_assoc($rObsoleteIndexes)) {
+			if (!@mysqli_query(%connid, "DROP INDEX ". $row['obsolete_key'] ." ON " . $db_settings['userdata_table'] .";")) {
+				$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+			}
+		}
+	}
 }
 
 if (empty($update['errors'])) {

--- a/update/update_2.4.19.1-2.5.php
+++ b/update/update_2.4.19.1-2.5.php
@@ -431,6 +431,9 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19.1',
 	if (!@mysqli_query($connid, "ALTER TABLE `" . $db_settings['userdata_table'] . "` DROP INDEX `user_name`, ADD UNIQUE KEY `key_user_name` (`user_name`);")) {
 		$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 	}
+	if (!@mysqli_query($connid, "ALTER TABLE `" . $db_settings['userdata_table'] . "` CHANGE `user_email` `user_email` VARCHAR(256) CHARACTER SET utf8 NOT NULL UNIQUE;")) {
+		$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+	}
 	if (!@mysqli_query($connid, "ALTER TABLE `" . $db_settings['userdata_table'] . "` ADD UNIQUE KEY `key_user_email` (`user_email`);")) {
 		$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 	}

--- a/update/update_2.4.19.1-2.5.php
+++ b/update/update_2.4.19.1-2.5.php
@@ -431,7 +431,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19.1',
 	if (!@mysqli_query($connid, "ALTER TABLE `" . $db_settings['userdata_table'] . "` DROP INDEX `user_name`, ADD UNIQUE KEY `key_user_name` (`user_name`);")) {
 		$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 	}
-	if (!@mysqli_query($connid, "ALTER TABLE `" . $db_settings['userdata_table'] . "` CHANGE `user_email` `user_email` VARCHAR(256) CHARACTER SET utf8 NOT NULL UNIQUE;")) {
+	if (!@mysqli_query($connid, "ALTER TABLE `" . $db_settings['userdata_table'] . "` CHANGE `user_email` `user_email` VARCHAR(256) CHARACTER SET utf8 NOT NULL;")) {
 		$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 	}
 	if (!@mysqli_query($connid, "ALTER TABLE `" . $db_settings['userdata_table'] . "` ADD UNIQUE KEY `key_user_email` (`user_email`);")) {
@@ -454,7 +454,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19.1',
 
 if (empty($update['errors']) && in_array($settings['version'], array('2.4.19.1', '2.4.20', '2.4.21', '2.4.22', '2.4.23', '2.4.24', '2.4.99.0', '2.4.99.1', '2.4.99.2', '2.4.99.3', '20220508.1', '20220509.1'))) {
 	// changed tables
-	if (!@mysqli_query($connid, "ALTER TABLE `" . $db_settings['userdata_table'] . "` CHANGE `user_email` `user_email` VARCHAR(256) CHARACTER SET utf8 NOT NULL UNIQUE;")) {
+	if (!@mysqli_query($connid, "ALTER TABLE `" . $db_settings['userdata_table'] . "` CHANGE `user_email` `user_email` VARCHAR(256) CHARACTER SET utf8 NOT NULL;")) {
 		$update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 	}
 }


### PR DESCRIPTION
… to prevent an index size error during the upgrade. This happens (depending on the MySQL version) when adding the index `key_user_email`, in case of a maximal index size of 767 bytes.

The charset has to be corrected *before* the index gets added. The code manipulates the upgrade section for version 2.4.99.2. The identical database query is also part of the upgrade to version 20220517.1. I was not able to produce an error when altering the column definition once with the upgrade to 2.4.99.2 and again with and to the identical settings when upgrading to the current master. So I tend to assume, that the script will not break.