### PR TITLE
Put the links in the usermenu to the (right) end of the box

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -47,7 +47,7 @@ body > *:not(main)       { margin:0; padding:0; }
 
 #nav                     { margin:0; padding:7px 20px; }
 
-#usermenu                { margin:0 0 0.75em 0; padding:0; font-size:0.69em; list-style-type:none; display:flex; flex-wrap:wrap; gap:3px 0.4em; }
+#usermenu                { margin:0 0 0.75em 0; padding:0; font-size:0.69em; list-style-type:none; display:flex; flex-wrap:wrap; justify-content:flex-end; gap:3px 0.4em; }
 #usermenu li             { margin:0; }
 #usermenu li:not(:last-child):after
                          { content: "|"; }

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -27,7 +27,7 @@ body > *:not(main){margin:0;padding:0}
 #logo h1 a:focus,#logo h1 a:hover{color:#00a;text-decoration:none}
 #logo .index{margin:0;padding:0;font-size:.82em}
 #nav{margin:0;padding:7px 20px}
-#usermenu{margin:0 0 0.75em;padding:0;font-size:.69em;list-style-type:none;display:flex;flex-wrap:wrap;gap:3px 0.4em}
+#usermenu{margin:0 0 0.75em;padding:0;font-size:.69em;list-style-type:none;display:flex;flex-wrap:wrap;justify-content:flex-end;gap:3px 0.4em}
 #usermenu li{margin:0}
 #usermenu li:not(:last-child):after{content:"|"}
 #usermenu li:not(:last-child) a{margin-right:0.4em}


### PR DESCRIPTION
Before the current solution with a flexbox the user menu list was defined as `display: inline;` with the addition of `text-align: right`. Now it is a flexbox and so it is necessary to put the flex items to the end of the flexbox to get the same look as before (right aligned items).