### PR TITLE
Prevent passwords from spell checking for the case of displaying them with type="text"

### DIFF
--- a/themes/default/subtemplates/admin.inc.tpl
+++ b/themes/default/subtemplates/admin.inc.tpl
@@ -658,7 +658,7 @@
 <p><label for="ar_email" class="main">{#register_email#}</label><br />
 <input id="ar_email" type="text" size="25" name="ar_email" value="{$ar_email|default:''}" maxlength="{$settings.email_maxlength}" /></p>
 <p><label for="ar_pw" class="main">{#register_pw#}</label><br />
-<input id="ar_pw" type="password" size="25" name="ar_pw" maxlength="50" /></p>
+<input id="ar_pw" type="password" spellcheck="false" autocomplete="off" size="25" name="ar_pw" maxlength="50" /></p>
 <p><input id="ar_send_userdata" type="checkbox" name="ar_send_userdata" value="true"{if $ar_send_userdata} checked="checked"{/if} /> <label for="ar_send_userdata">{#register_send_userdata#}</label></p>
 <p><input type="submit" name="register_submit" value="{#submit_button_ok#}" /></p>
 </div>
@@ -846,7 +846,7 @@
 <p><input id="delete_postings" type="checkbox" name="delete_postings" value="true" /><label for="delete_postings"> {#delete_postings#}</label></p>
 <p><input id="delete_userdata" type="checkbox" name="delete_userdata" value="true" /><label for="delete_userdata"> {#delete_userdata#}</label></p>
 <p>{#admin_confirm_password#}<br />
-<input type="password" size="20" name="confirm_pw" /> <input type="submit" name="reset_forum_confirmed" value="{#reset_forum_submit#}" /></p>
+<input type="password" spellcheck="false" autocomplete="off" size="20" name="confirm_pw" /> <input type="submit" name="reset_forum_confirmed" value="{#reset_forum_submit#}" /></p>
 </div>
 </form>
 
@@ -859,7 +859,7 @@
 <input type="hidden" name="mode" value="admin" />
 <input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />
 <p>{#reset_uninstall_conf_pw#}<br />
-<input type="password" size="20" name="confirm_pw" /> <input type="submit" name="uninstall_forum_confirmed" value="{#uninstall_forum_submit#}" /></p>
+<input type="password" spellcheck="false" autocomplete="off" size="20" name="confirm_pw" /> <input type="submit" name="uninstall_forum_confirmed" value="{#uninstall_forum_submit#}" /></p>
 </div>
 </form>
 {elseif $action=='update'}
@@ -895,7 +895,7 @@
 <input type="hidden" name="mode" value="admin" />
 <input type="hidden" name="update_file_submit" value="{$update_file}" />
 <input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />
-<p>{#admin_confirm_password#}<br /><input type="password" name="update_password" size="25"/></p>
+<p>{#admin_confirm_password#}<br /><input type="password" name="update_password" spellcheck="false" autocomplete="off" size="25"/></p>
 <p><input type="submit" name="update_submit" value="{#update_submit#}" onclick="document.getElementById('throbber-submit').style.visibility = 'visible';" /> <img id="throbber-submit" style="visibility:hidden;" src="{$THEMES_DIR}/{$theme}/images/throbber_submit.gif" alt="" width="16" height="16" /></p>
 </div>
 </form>

--- a/themes/default/subtemplates/login.inc.tpl
+++ b/themes/default/subtemplates/login.inc.tpl
@@ -12,7 +12,7 @@
 {if $back}<input type="hidden" name="back" value="{$back}" />{/if}
 {if $id}<input type="hidden" name="id" value="{$id}" />{/if}
 <p><label for="login" class="main">{#login_username#}</label><br /><input id="login" class="login" type="text" name="username" size="25" /></p>
-<p><label for="password" class="main">{#login_password#}</label><br /><input id="password" class="login" type="password" name="userpw" size="25" /></p>
+<p><label for="password" class="main">{#login_password#}</label><br /><input id="password" class="login" type="password" name="userpw" spellcheck="false" autocomplete="off" size="25" /></p>
 {if $settings.autologin==1}
 <p class="small"><input id="autologin" type="checkbox" name="autologin_checked" value="true" /> <label for="autologin">{#login_auto#}</label></p>
 {/if}

--- a/themes/default/subtemplates/register.inc.tpl
+++ b/themes/default/subtemplates/register.inc.tpl
@@ -20,7 +20,7 @@
 <input id="new_user_name" class="login" type="text" size="30" name="{$fld_user_name}" value="{$new_user_name|default:''}" maxlength="{$settings.username_maxlength}" tabindex="1" /></p>
 
 <p><label for="reg_pw" class="main">{#register_pw#}</label><br />
-<input id="reg_pw" class="login" type="password" size="30" name="{$fld_pword}" maxlength="255" tabindex="2" /></p>
+<input id="reg_pw" class="login" type="password" spellcheck="false" autocomplete="off" size="30" name="{$fld_pword}" maxlength="255" tabindex="2" /></p>
 
 <p class="hp"><label for="phone" class="main">{#register_honeypot_field#}</label><br />
 <input id="phone" class="login" type="text" size="30" name="{$fld_phone}" value="{$honey_pot_phone|default:''}" maxlength="35" tabindex="-1" /></p>

--- a/themes/default/subtemplates/user_edit_email.inc.tpl
+++ b/themes/default/subtemplates/user_edit_email.inc.tpl
@@ -19,7 +19,7 @@
 <p><label for="new_email_confirm" class="main">{#edit_email_new_confirm#}</label><br />
 <input id="new_email_confirm" type="text" size="25" name="new_email_confirm" value="" maxlength="{$settings.email_maxlength}" /></p>
 <p><label for="pw_new_email" class="main">{#edit_email_pw#}</label><br />
-<input id="pw_new_email" type="password" size="25" name="pw_new_email" /></p>
+<input id="pw_new_email" type="password" spellcheck="false" autocomplete="off" size="25" name="pw_new_email" /></p>
 <p><input type="submit" name="edit_email_submit" value="{#submit_button_ok#}" /></p>
 </div>
 </form>

--- a/themes/default/subtemplates/user_edit_pw.inc.tpl
+++ b/themes/default/subtemplates/user_edit_pw.inc.tpl
@@ -13,9 +13,9 @@
 <input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />
 <input type="hidden" name="mode" value="user" />
 <p><strong>{#edit_pw_old#}</strong><br />
-<input type="password" size="25" name="old_pw" /></p>
+<input type="password" spellcheck="false" autocomplete="off" size="25" name="old_pw" /></p>
 <p><strong>{#edit_pw_new#}</strong><br />
-<input type="password" size="25" name="new_pw" maxlength="255" /></p>
+<input type="password" spellcheck="false" autocomplete="off" size="25" name="new_pw" maxlength="255" /></p>
 <p><input type="submit" name="edit_pw_submit" value="{#submit_button_ok#}" /></p>
 </div>
 </form>

--- a/themes/default/subtemplates/user_remove_account.inc.tpl
+++ b/themes/default/subtemplates/user_remove_account.inc.tpl
@@ -15,7 +15,7 @@
 		<input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />
 		<input type="hidden" name="mode" value="user" />
 		<input type="hidden" name="action" value="edit_profile" />
-		<p><strong><label for="password">{#remove_user_confirm_password#}</label></strong><br /><input id="password" type="password" name="user_password" size="25" /></p>
+		<p><strong><label for="password">{#remove_user_confirm_password#}</label></strong><br /><input id="password" type="password" name="user_password" spellcheck="false" autocomplete="off" size="25" /></p>
 		<input type="submit" name="remove_account_submit" value="{#submit_button_ok#}" />
 		<input type="submit" value="{#submit_button_cancel#}">
 	</form>


### PR DESCRIPTION
This is necessary in browsers which sends content of an input field with type text to external spell checking services, as Chrome does with sending the content to a Google service.

We implemented the function to display an password in its input of type *password* with changing the type to *text* with JavaScript. In this moment the content of the input field is simply text that can be handled by the browsers internal spell checking function. If a browser sends the input content to an external service, as Chrome does, a password will be immediately exposed to this external service. Even it is not marked as a password in this moment, it is undesirable to expose passwords to any external entity at all.

fixes #644 