### PR TITLE
Change HTML and CSS for system messages

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -275,14 +275,22 @@ ul.openthread            { clear:both; }
 #admin-usernav-bottom #userpagination
                          { float:right; height:2em; text-align:right; }
 
-.spam                    { color:#882008; font-weight:bold; background:yellow; }
-.spam-note               { font-weight:bold; color:#882008; background:yellow; border:1px solid #882008; padding:0.5em; }
 .thread ul               { font-size:1em; }
 .thread li               { font-size:1em; }
 .thread li li            { font-size:1em; }
 .thrbeg                  { font-weight:bold; }
-.caution                 { padding:0 0 0 20px; color:red; font-weight:bold; background:url(images/caution.png) no-repeat left center; }
-.ok                      { padding:0 0 0 20px; font-weight:bold; color:red; background:url(images/tick.png) no-repeat left center; }
+
+.spam, .caution, .ok     { font-weight:bold; }
+.spam, .caution          { color:#882008; background-color:#ff5; }
+.notice                  { border:1px solid; }
+.notice.spam             { padding:.5em; }
+.notice.spam, .notice.caution
+                         { border-color:#882008; }
+.notice.caution, .notice.ok
+                         { padding:0.5em 0.5em 0.5em 1.75em; }
+.notice.caution          { background:url(images/caution.png) no-repeat 0.375em center; }
+.notice.ok               { color:#086620; background:#5fa url(images/tick.png) no-repeat 0.375em center; border-color:#086620; }
+
 .entryline               { clear:both; margin:15px 0 15px 0; border-top:1px dotted #808080; border-left:0; border-right:0; border-bottom:0; height:1px; }
 .marked-threads          { margin:30px 0 0 0; font-size:11px; }
 .marked-threads-board    { margin:10px 1px 0 1px; font-size:11px; }

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -275,8 +275,8 @@ ul.openthread            { clear:both; }
 #admin-usernav-bottom #userpagination
                          { float:right; height:2em; text-align:right; }
 
-.spam                    { color:#ff0000; font-weight:bold; background:yellow; }
-.spam-note               { font-weight:bold; color:red; background:yellow; padding:5px; }
+.spam                    { color:#882008; font-weight:bold; background:yellow; }
+.spam-note               { font-weight:bold; color:#882008; background:yellow; border:1px solid #882008; padding:0.5em; }
 .thread ul               { font-size:1em; }
 .thread li               { font-size:1em; }
 .thread li li            { font-size:1em; }

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -186,14 +186,18 @@ ul.openthread{clear:both}
 #selectioncontrols #arrow-selected{margin:0 0 0 13px}
 #selectioncontrols .checkall{margin-left:1em;font-size:.69em}
 #admin-usernav-bottom #userpagination{float:right;height:2em;text-align:right}
-.spam{color:#882008;font-weight:700;background:#ff5}
-.spam-note{font-weight:700;color:#882008;background:#ff5;border:1px solid #882008;padding:.5em}
 .thread ul{font-size:1em}
 .thread li{font-size:1em}
 .thread li li{font-size:1em}
 .thrbeg{font-weight:700}
-.caution{padding:0 0 0 20px;color:red;font-weight:700;background:url(images/caution.png) no-repeat left center}
-.ok{padding:0 0 0 20px;font-weight:700;color:red;background:url(images/tick.png) no-repeat left center}
+.spam,.caution,.ok{font-weight:bold}
+.spam,.caution{color:#882008;background-color:#ff5}
+.notice{border:1px solid}
+.notice.spam{padding:.5em}
+.notice.spam,.notice.caution{border-color:#882008}
+.notice.caution,.notice.ok{padding:.5em .5em .5em 1.75em}
+.notice.caution{background:url(images/caution.png) no-repeat 0.375em center}
+.notice.ok{color:#086620;background:#5fa url(images/tick.png) no-repeat 0.375em center;border-color:#086620}
 .entryline{clear:both;margin:15px 0;border-top:1px dotted gray;border-left:0;border-right:0;border-bottom:0;height:1px}
 .marked-threads{margin:30px 0 0;font-size:11px}
 .marked-threads-board{margin:10px 1px 0;font-size:11px}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -186,8 +186,8 @@ ul.openthread{clear:both}
 #selectioncontrols #arrow-selected{margin:0 0 0 13px}
 #selectioncontrols .checkall{margin-left:1em;font-size:.69em}
 #admin-usernav-bottom #userpagination{float:right;height:2em;text-align:right}
-.spam{color:red;font-weight:700;background:#ff0}
-.spam-note{font-weight:700;color:red;background:#ff0;padding:5px}
+.spam{color:#882008;font-weight:700;background:#ff5}
+.spam-note{font-weight:700;color:#882008;background:#ff5;border:1px solid #882008;padding:.5em}
 .thread ul{font-size:1em}
 .thread li{font-size:1em}
 .thread li li{font-size:1em}

--- a/themes/default/subtemplates/admin.inc.tpl
+++ b/themes/default/subtemplates/admin.inc.tpl
@@ -1,6 +1,6 @@
 {config_load file=$language_file section="admin"}
 {if $action=='settings'}
-{if $saved}<p class="ok">{#settings_saved#}</p>{/if}
+{if $saved}<p class="notice ok">{#settings_saved#}</p>{/if}
 <form id="settings" action="index.php" method="post" accept-charset="{#charset#}">
 <div>
 <input type="hidden" name="mode" value="admin" />
@@ -235,7 +235,7 @@
 </form>
 <p style="margin-top:10px;"><a class="stronglink" href="index.php?mode=admin&amp;action=advanced_settings">{#advanced_settings_link#}</a></p>
 {elseif $action=='advanced_settings'}
-{if $saved}<p class="ok">{#settings_saved#}</p>{/if}
+{if $saved}<p class="notice ok">{#settings_saved#}</p>{/if}
 <form action="index.php" method="post" accept-charset="{#charset#}">
 <div>
 <input type="hidden" name="mode" value="admin" />
@@ -274,7 +274,7 @@
 </form>
 {/if}
 {if $errors}
-<p class="caution">{#error_headline#}</p>
+<p class="notice caution">{#error_headline#}</p>
 <ul>
 {section name=mysec loop=$errors}
 {assign var="error" value=$errors[mysec]}
@@ -324,7 +324,7 @@
 </form>
 {elseif $action=='edit_category'}
 {if $errors}
-<p class="caution">{#error_headline#}</p>
+<p class="notice caution">{#error_headline#}</p>
 <ul>
 {section name=mysec loop=$errors}
 {assign var="error" value=$errors[mysec]}
@@ -348,7 +348,7 @@
 </form>
 {elseif $action=='delete_category'}
 {if $errors}
-<p class="caution">{#error_headline#}</p>
+<p class="notice caution">{#error_headline#}</p>
 <ul>
 {section name=mysec loop=$errors}
 {assign var="error" value=$errors[mysec]}
@@ -357,7 +357,7 @@
 </ul>
 {/if}
 <h2>{#delete_category_hl#|replace:"[category]":$category_name}</h2>
-<p class="caution">{#caution#}</p>
+<p class="notice caution">{#caution#}</p>
 <form action="index.php" method="post" accept-charset="{#charset#}">
 <div>
 <input type="hidden" name="mode" value="admin" />
@@ -378,7 +378,7 @@
 </form>
 {elseif $action=='user'}
 <h2 id="admin_header">{#user_list_header#}</h2>
-{if $new_user && !$send_error}<p class="ok">{#new_user_registered#|replace:"[name]":$new_user}</p>{elseif $new_user && $send_error}<p class="caution">{#new_user_reg_send_error#|replace:"[name]":$new_user}</p>{/if}
+{if $new_user && !$send_error}<p class="notice ok">{#new_user_registered#|replace:"[name]":$new_user}</p>{elseif $new_user && $send_error}<p class="notice caution">{#new_user_reg_send_error#|replace:"[name]":$new_user}</p>{/if}
 {*<p>{#num_registerd_users#|replace:"[number]":$total_users}</p>*}
 
 <div id="usersearch">
@@ -403,7 +403,7 @@
 {/if}
 
 {if $result_count > 0}
-{if $no_users_in_selection}<p class="caution">{#no_users_in_sel#}</p>{/if}
+{if $no_users_in_selection}<p class="notice caution">{#no_users_in_sel#}</p>{/if}
 <form action="index.php" method="post" accept-charset="{#charset#}">
 <div>
 <input type="hidden" name="mode" value="admin" />
@@ -474,7 +474,7 @@
 {elseif $action=='edit_user'}
 {config_load file=$language_file section="user_edit"}
 {if $errors}
-<p class="caution">{#error_headline#}</p>
+<p class="notice caution">{#error_headline#}</p>
 <ul>
 {section name=mysec loop=$errors}
 {assign var="error" value=$errors[mysec]}
@@ -482,7 +482,7 @@
 {/section}
 </ul>
 {/if}
-{if $inactive}<p class="caution">{#caution#}</p><p>{#activate_note#} <a href="index.php?mode=admin&amp;activate={$edit_user_id}">{#activate_link#}</a></p>{/if}
+{if $inactive}<p class="notice caution">{#caution#}</p><p>{#activate_note#} <a href="index.php?mode=admin&amp;activate={$edit_user_id}">{#activate_link#}</a></p>{/if}
 <form action="index.php" method="post" accept-charset="{#charset#}">
 <div>
 <input type="hidden" name="mode" value="admin" />
@@ -603,7 +603,7 @@
 </div>
 </form>
 {elseif $action=='delete_users'}
-<p class="caution">{#caution#}</p>
+<p class="notice caution">{#caution#}</p>
 <p>{if $selected_users_count>1}{#delete_users_confirmation#}{else}{#delete_user_confirmation#}{/if}</p>
 <ul>
 {section name=nr loop=$selected_users}
@@ -622,7 +622,7 @@
 </div>
 </form>
 {elseif $action=='user_delete_entries'}
-<p class="caution">{#caution#}</p>
+<p class="notice caution">{#caution#}</p>
 <p>{#delete_entries_of_user_confirm#|replace:"[user]":$user_delete_entries['user']}</p>
 <form action="index.php" method="post" accept-charset="{#charset#}">
 <div>
@@ -634,7 +634,7 @@
 </form>
 {elseif $action=='register'}
 {if $errors}
-<p class="caution">{#error_headline#}</p>
+<p class="notice caution">{#error_headline#}</p>
 <ul>
 {section name=mysec loop=$errors}
 {assign var="error" value=$errors[mysec]}
@@ -659,7 +659,7 @@
 <p class="small">{#register_exp#}</p>
 {elseif $action=='smilies'}
 {if $errors}
-<p class="caution">{#error_headline#}</p>
+<p class="notice caution">{#error_headline#}</p>
 <ul>
 {section name=mysec loop=$errors}
 {assign var="error" value=$errors[mysec]}
@@ -728,7 +728,7 @@
 </ul>
 {elseif $action=='spam_protection'}
 {if $errors}
-<p class="caution">{#error_headline#}</p>
+<p class="notice caution">{#error_headline#}</p>
 <ul>
 {section name=mysec loop=$errors}
 {assign var="error" value=$errors[mysec]}
@@ -736,7 +736,7 @@
 {/section}
 </ul>
 {/if}
-{if $saved}<p class="ok">{#spam_protection_saved#}</p>{/if}
+{if $saved}<p class="notice ok">{#spam_protection_saved#}</p>{/if}
 <form action="index.php" method="post" accept-charset="{#charset#}">
 <div>
 <input type="hidden" name="mode" value="admin" />
@@ -828,7 +828,7 @@
 </div>
 </form>
 {elseif $action=='reset_uninstall'}
-<p class="caution">{#caution#}</p>
+<p class="notice caution">{#caution#}</p>
 {if $errors}{include file="$theme/subtemplates/errors.inc.tpl"}{/if}
 
 <h2>{#reset_forum#}</h2>
@@ -866,7 +866,7 @@
 </ul>
 
 {if $errors}{include file="$theme/subtemplates/errors.inc.tpl"}{/if}
-{if $message}<p class="ok">{$smarty.config.$message}</p>{/if}
+{if $message}<p class="notice ok">{$smarty.config.$message}</p>{/if}
 {if $update_files}
 <h3>{#update_available_files#}</h3>
 <ul>
@@ -878,7 +878,7 @@
 <p><em>{#update_no_files_available#}</em></p>
 {/if}
 {elseif $action=='run_update'}
-<p class="caution">{#caution#}</p>
+<p class="notice caution">{#caution#}</p>
 <p>{#update_confirm#}</p>
 <p><strong>{$update_file}</strong>{if $update_from_version && $update_to_version} {#update_file_details#|replace:"[update_from_version]":$update_from_version|replace:"[update_to_version]":$update_to_version}{/if}</p>
 <p style="color:red;font-weight:bold;">{#update_note#}</p>
@@ -894,7 +894,7 @@
 </form>
 {elseif $action=='update_done'}
 {if $update_errors}
-<p class="caution">{#error_headline#}</p>
+<p class="notice caution">{#error_headline#}</p>
 <ul>
 {section name=mysec loop=$update_errors}
 {assign var="error" value=$update_errors[mysec]}
@@ -902,7 +902,7 @@
 {/section}
 </ul>
 {else}
-<p class="ok">{#update_successful#}</p>
+<p class="notice ok">{#update_successful#}</p>
 {/if}
 {if $update_items}
 <p>{#update_items_note#|replace:"[version]":$update_new_version}</p>
@@ -917,7 +917,7 @@
 {elseif $action == 'email_list'}
 <textarea onfocus="this.select()" onclick="this.select()" readonly="readonly" cols="60" rows="15">{$email_list}</textarea>
 {elseif $action == 'clear_userdata'}
-{if $no_users_in_selection}<p class="caution">{#no_users_in_selection#}</p>{/if}
+{if $no_users_in_selection}<p class="notice caution">{#no_users_in_selection#}</p>{/if}
 {assign var="input_logins" value="<input type=\"text\" name=\"logins\" value=\"$logins\" size=\"4\" />"}
 {assign var="input_days" value="<input type=\"text\" name=\"days\" value=\"$days\" size=\"4\" />"}
 <form action="index.php" method="post" accept-charset="{#charset#}">
@@ -930,7 +930,7 @@
 <p class="small">{#clear_userdata_note#}</p>
 {elseif $action == 'edit_smiley'}
 {if $errors}
-<p class="caution">{#error_headline#}</p>
+<p class="notice caution">{#error_headline#}</p>
 <ul>
 {section name=mysec loop=$errors}
 {assign var="error" value=$errors[mysec]}
@@ -996,7 +996,7 @@
 <ul class="adminmenu"><li><a href="index.php?mode=admin&amp;action=edit_page"><img src="{$THEMES_DIR}/{$theme}/images/add_page.png" alt="" width="16" height="16" /><span>{#add_page_link#}</span></a></li></ul>
 {elseif $action=='edit_page'}
 {if $errors}
-<p class="caution">{#error_headline#}</p>
+<p class="notice caution">{#error_headline#}</p>
 <ul>
 {section name=mysec loop=$errors}
 {assign var="error" value=$errors[mysec]}
@@ -1036,7 +1036,7 @@
 </form>
 {elseif $action=='delete_page'}
 {if $page}
-<p class="caution">{#caution#}</p>
+<p class="notice caution">{#caution#}</p>
 <p>{#delete_page_confirm#}</p>
 <p><strong>{$page.title}</strong></p>
 <form action="index.php" method="post" accept-charset="{#charset#}">
@@ -1091,7 +1091,7 @@
 {/if}
 {elseif $action=='delete_uploads'}
 <h2 id="admin_header">{#upload_administration#}</h2>
-<p class="caution">{#caution#}</p>
+<p class="notice caution">{#caution#}</p>
 <p>{if $selected_uploads_count>1}{#delete_uploads_confirmation#}{else}{#delete_upload_confirmation#}{/if}</p>
 <form action="index.php" method="post" accept-charset="{#charset#}">
 <div>

--- a/themes/default/subtemplates/bookmark.inc.tpl
+++ b/themes/default/subtemplates/bookmark.inc.tpl
@@ -42,7 +42,7 @@
 	
 {elseif $action=='delete_bookmark'}
 	{if $bookmark}
-		<p class="caution">{#caution#}</p>
+		<p class="notice caution">{#caution#}</p>
 		<p>{#delete_bookmark_confirm#}</p>
 		<p><strong>{$bookmark.subject}</strong></p>
 		<form action="index.php" method="post" accept-charset="{#charset#}">
@@ -58,7 +58,7 @@
 	
 {elseif $action=='edit_bookmark'}
 	{if $errors}
-		<p class="caution">{#error_headline#}</p>
+		<p class="notice caution">{#error_headline#}</p>
 		<ul style="margin-bottom:25px;">
 		{section name=mysec loop=$errors}
 			<li>{assign var="error" value=$errors[mysec]}{$smarty.config.$error|replace:"[word]":$word}</li>

--- a/themes/default/subtemplates/contact.inc.tpl
+++ b/themes/default/subtemplates/contact.inc.tpl
@@ -1,13 +1,13 @@
 {config_load file=$language_file section="contact"}
 {if $captcha}{config_load file=$language_file section="captcha"}{/if}
 {if $error_message}
-<p class="caution">{$smarty.config.$error_message}</p>
+<p class="notice caution">{$smarty.config.$error_message}</p>
 {elseif $sent}
-<p class="ok">{#email_sent#}</p>
+<p class="notice ok">{#email_sent#}</p>
 {else}
 <h1>{if $recipient_name}{$smarty.config.contact_user_hl|replace:"[recipient_name]":"$recipient_name"}{else}{#contact_hl#}{/if}</h1>
 {if $errors}
-<p class="caution">{#error_headline#}</p>
+<p class="notice caution">{#error_headline#}</p>
 <ul>
 {section name=mysec loop=$errors}
 {assign var="error" value=$errors[mysec]}

--- a/themes/default/subtemplates/entry.inc.tpl
+++ b/themes/default/subtemplates/entry.inc.tpl
@@ -25,7 +25,7 @@
 {assign var=name value="<a href=\"index.php?mode=user&amp;show_user=$posting_user_id\">$name</a>"}
 {/if}
 <article class="posting{if $is_read} read{/if}">
-<header class="header">{if $spam}<p class="spam-note">{#spam_note#}</p>{/if}
+<header class="header">{if $spam}<p class="notice spam">{#spam_note#}</p>{/if}
 {if $avatar}<img class="avatar" src="{$avatar.image}" alt="{#avatar_img_alt#}" width="{$avatar.width}" height="{$avatar.height}" />{/if}
 <h1>{$subject}{if $category_name} <span class="category">({$category_name})</span>{/if}</h1>
 <p class="author">{*{assign var=formated_time value=$disp_time|date_format:#time_format_full#}*}{if $location}{#posted_by_location#|replace:"[name]":$name|replace:"[email_hp]":$email_hp|replace:"[location]":$location|replace:"[time]":$formated_time}{else}{#posted_by#|replace:"[name]":$name|replace:"[email_hp]":$email_hp|replace:"[time]":$formated_time}{/if} <span class="ago">({if $ago.days>1}{#posting_several_days_ago#|replace:"[days]":$ago.days_rounded}{else}{if $ago.days==0 && $ago.hours==0}{#posting_minutes_ago#|replace:"[minutes]":$ago.minutes}{elseif $ago.days==0 && $ago.hours!=0}{#posting_hours_ago#|replace:"[hours]":$ago.hours|replace:"[minutes]":$ago.minutes}{else}{#posting_one_day_ago#|replace:"[hours]":$ago.hours|replace:"[minutes]":$ago.minutes}{/if}{/if})</span>{if $admin && $ip} <span class="ip">({$ip})</span>{/if}{if $pid!=0} <span class="op-link"><a href="index.php?id={$pid}" title="{#original_posting_linktitle#|replace:"[name]":$data.$pid.name}">@ {$data.$pid.name}</a></span>{/if}{if $edited}{*{assign var=formated_edit_time value=$edit_time|date_format:#time_format_full#}*}<br />

--- a/themes/default/subtemplates/errors.inc.tpl
+++ b/themes/default/subtemplates/errors.inc.tpl
@@ -1,4 +1,4 @@
-<p class="caution">{#error_headline#}</p>
+<p class="notice caution">{#error_headline#}</p>
 <ul>
 {section name=mysec loop=$errors}
 {assign var="error" value=$errors[mysec]}

--- a/themes/default/subtemplates/login.inc.tpl
+++ b/themes/default/subtemplates/login.inc.tpl
@@ -1,10 +1,10 @@
 {config_load file=$language_file section="login"}
 {if $ip_temporarily_blocked}
 {#login_message#}
-<p class="caution">{#login_ip_temp_blocked#}</p>
+<p class="notice caution">{#login_ip_temp_blocked#}</p>
 {else}
 {if $login_message && $smarty.config.$login_message}
-<p class="{if $login_message=='account_activated' || $login_message=='mail_sent' || $login_message=='pw_sent'}ok{else}caution{/if}">{$smarty.config.$login_message}</p>
+<p class="notice {if $login_message=='account_activated' || $login_message=='mail_sent' || $login_message=='pw_sent'}ok{else}caution{/if}">{$smarty.config.$login_message}</p>
 {/if}
 <form action="index.php" method="post" accept-charset="{#charset#}">
 <div>

--- a/themes/default/subtemplates/page.inc.tpl
+++ b/themes/default/subtemplates/page.inc.tpl
@@ -1,7 +1,7 @@
 {if $no_authorisation}
-<p class="caution">{#no_authorisation#}</p>
+<p class="notice caution">{#no_authorisation#}</p>
 {elseif $page}
 {$page.content}
 {else}
-<p class="caution">{#page_doesnt_exist#}</p>
+<p class="notice caution">{#page_doesnt_exist#}</p>
 {/if}

--- a/themes/default/subtemplates/posting.inc.tpl
+++ b/themes/default/subtemplates/posting.inc.tpl
@@ -2,7 +2,7 @@
 {config_load file=$language_file section="thread_entry"}
 {if $captcha}{config_load file=$language_file section="captcha"}{/if}
 {if $no_authorisation}
-<p class="caution">{$smarty.config.$no_authorisation|replace:"[minutes]":$settings.edit_period}</p>
+<p class="notice caution">{$smarty.config.$no_authorisation|replace:"[minutes]":$settings.edit_period}</p>
 {if $text}
 <textarea onfocus="this.select()" onclick="this.select()" readonly="readonly" cols="80" rows="21" name="text">{$text}</textarea>
 {/if}
@@ -13,14 +13,14 @@
 {/if}
 
 {if $errors}
-<p class="caution">{#error_headline#}</p>
+<p class="notice caution">{#error_headline#}</p>
 <ul style="margin-bottom:25px;">
 {section name=mysec loop=$errors}
 <li>{assign var="error" value=$errors[mysec]}{$smarty.config.$error|replace:"[text_length]":$text_length|replace:"[text_maxlength]":$settings.text_maxlength|replace:"[word]":$word|replace:"[minutes]":$minutes|replace:"[not_accepted_word]":$not_accepted_word|replace:"[not_accepted_words]":$not_accepted_words}</li>
 {/section}
 </ul>
 {elseif isset($minutes_left_to_edit)}
-<p class="caution">{if $settings.user_edit_if_no_replies==1}{#minutes_left_to_edit_reply#|replace:"[minutes]":$minutes_left_to_edit}{else}{#minutes_left_to_edit#|replace:"[minutes]":$minutes_left_to_edit}{/if}</p>
+<p class="notice caution">{if $settings.user_edit_if_no_replies==1}{#minutes_left_to_edit_reply#|replace:"[minutes]":$minutes_left_to_edit}{else}{#minutes_left_to_edit#|replace:"[minutes]":$minutes_left_to_edit}{/if}</p>
 {/if}
 
 {if $preview}

--- a/themes/default/subtemplates/posting_delete.inc.tpl
+++ b/themes/default/subtemplates/posting_delete.inc.tpl
@@ -1,9 +1,9 @@
 {config_load file=$language_file section="delete_posting"}
 {if $no_authorisation}
-<p class="caution">{$smarty.config.$no_authorisation}</p>
+<p class="notice caution">{$smarty.config.$no_authorisation}</p>
 {else}
 <h1>{#delete_postings_hl#}</h1>
-<p class="caution">{#caution#}</p>
+<p class="notice caution">{#caution#}</p>
 <p>{if $admin||$mod}{#delete_posting_replies_confirm#}{else}{#delete_posting_confirm#}{/if}</p>
 <p><strong>{$subject}</strong> - <strong>{$name}</strong>, {$formated_time}</p>
 <form action="index.php" method="post" accept-charset="{#charset#}">

--- a/themes/default/subtemplates/posting_delete_marked.inc.tpl
+++ b/themes/default/subtemplates/posting_delete_marked.inc.tpl
@@ -1,9 +1,9 @@
 {config_load file=$language_file section="delete_posting"}
 {if $no_authorisation}
-<p class="caution">{$smarty.config.$no_authorisation}</p>
+<p class="notice caution">{$smarty.config.$no_authorisation}</p>
 {else}
 <h1>{#delete_marked_hl#}</h1>
-<p class="caution">{#caution#}</p>
+<p class="notice caution">{#caution#}</p>
 <p>{#delete_marked_confirm#}</p>
 <form action="index.php" method="post" accept-charset="{#charset#}">
 <div>

--- a/themes/default/subtemplates/posting_delete_spam.inc.tpl
+++ b/themes/default/subtemplates/posting_delete_spam.inc.tpl
@@ -1,9 +1,9 @@
 {config_load file=$language_file section="delete_posting"}
 {if $no_authorisation}
-<p class="caution">{#no_authorisation#}</p>
+<p class="notice caution">{#no_authorisation#}</p>
 {else}
 <h1>{#delete_spam_hl#}</h1>
-<p class="caution">{#caution#}</p>
+<p class="notice caution">{#caution#}</p>
 <p>{#delete_spam_confirm#}</p>
 <form action="index.php" method="post" accept-charset="{#charset#}">
 <div>

--- a/themes/default/subtemplates/posting_flag_ham.inc.tpl
+++ b/themes/default/subtemplates/posting_flag_ham.inc.tpl
@@ -1,6 +1,6 @@
 {config_load file=$language_file section="delete_posting"}
 {if $no_authorisation}
-	<p class="caution">{#no_authorisation#}</p>
+	<p class="notice caution">{#no_authorisation#}</p>
 {else}
 	<h1>{#flag_ham_hl#}</h1>
 	{if !$id}
@@ -8,7 +8,7 @@
 	{elseif $akismet_spam == 0 && $akismet_spam_check_status == 1 && $b8_spam == 0 && $b8_training_type == 1}
 		{#posting_not_flagged_as_spam#}
 	{else}
-		<p class="caution">{#caution#}</p>
+		<p class="notice caution">{#caution#}</p>
 		<p>{#flag_ham_warning#}</p>
 		<p><strong>{$subject}</strong> - <strong>{$name}</strong>, {$formated_time}</p>
 		<form action="index.php" method="post" accept-charset="{#charset#}">

--- a/themes/default/subtemplates/posting_manage_postings.inc.tpl
+++ b/themes/default/subtemplates/posting_manage_postings.inc.tpl
@@ -1,6 +1,6 @@
 {config_load file=$language_file section="manage_postings"}
 {if $no_authorisation}
-<p class="caution">{$smarty.config.$no_authorisation}</p>
+<p class="notice caution">{$smarty.config.$no_authorisation}</p>
 {else}
 {assign var='input_days' value='</label><input type="text" name="days" value="" size="5" />'}
 <h1>{#manage_postings_hl#}</h1>

--- a/themes/default/subtemplates/posting_move.inc.tpl
+++ b/themes/default/subtemplates/posting_move.inc.tpl
@@ -1,6 +1,6 @@
 {config_load file=$language_file section="move_posting"}
 {if $no_authorisation}
-<p class="caution">{$smarty.config.$no_authorisation}</p>
+<p class="notice caution">{$smarty.config.$no_authorisation}</p>
 {else}
 {assign var="input_move_to" value="<input type=\"text\" name=\"move_to\" value=\"\" size=\"5\" onclick=\"document.getElementById('move_mode_1').checked=false; document.getElementById('move_mode_1').checked='checked'; \" />"}
 <h1>{#move_posting_hl#}</h1>

--- a/themes/default/subtemplates/posting_report_spam.inc.tpl
+++ b/themes/default/subtemplates/posting_report_spam.inc.tpl
@@ -1,6 +1,6 @@
 {config_load file=$language_file section="delete_posting"}
 {if $no_authorisation}
-	<p class="caution">{#no_authorisation#}</p>
+	<p class="notice caution">{#no_authorisation#}</p>
 {else}
 	<h1>{#report_spam_hl#}</h1>
 	{if !$id}
@@ -8,7 +8,7 @@
 	{elseif $akismet_spam == 1 && $akismet_spam_check_status == 1 && $b8_spam == 1 && $b8_training_type == 2}
 		{#posting_already_spam#}
 	{else}
-		<p class="caution">{#caution#}</p>
+		<p class="notice caution">{#caution#}</p>
 		<p>{#report_spam_warning#}</p>
 		<p>{if $akismet_spam_check_status==2}{#spamcheck_akismet_timeout_error#}{/if}</p>
 		<p>{if $akismet_spam_check_status==3}{#spamcheck_akismet_api_error#}{/if}</p>

--- a/themes/default/subtemplates/posting_unsubscribe.inc.tpl
+++ b/themes/default/subtemplates/posting_unsubscribe.inc.tpl
@@ -4,5 +4,5 @@
 <p>{#unsubscribed_message#}</p>
 {else}
 <h2>{#unsubscribe_error_hl#}</h2>
-<p class="caution">{#unsubscribe_error_message#}</p>
+<p class="notice caution">{#unsubscribe_error_message#}</p>
 {/if}

--- a/themes/default/subtemplates/register.inc.tpl
+++ b/themes/default/subtemplates/register.inc.tpl
@@ -2,7 +2,7 @@
 {if $captcha}{config_load file=$language_file section="captcha"}{/if}
 <p class="normal">{#register_exp#}</p>
 {if $errors}
-<p class="caution">{#error_headline#}</p>
+<p class="notice caution">{#error_headline#}</p>
 <ul>
 {section name=mysec loop=$errors}
 {assign var="error" value=$errors[mysec]}

--- a/themes/default/subtemplates/user_edit.inc.tpl
+++ b/themes/default/subtemplates/user_edit.inc.tpl
@@ -1,6 +1,6 @@
 {config_load file=$language_file section="user_edit"}
 {if $errors}
-<p class="caution">{#error_headline#}</p>
+<p class="notice caution">{#error_headline#}</p>
 <ul>
 {section name=mysec loop=$errors}
 {assign var="error" value=$errors[mysec]}
@@ -8,7 +8,7 @@
 {/section}
 </ul>
 {/if}
-{if $msg}<p class="ok">{$smarty.config.$msg}</p>{/if}
+{if $msg}<p class="notice ok">{$smarty.config.$msg}</p>{/if}
 <form action="index.php" method="post" accept-charset="{#charset#}">
 <div>
 <input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />

--- a/themes/default/subtemplates/user_edit_email.inc.tpl
+++ b/themes/default/subtemplates/user_edit_email.inc.tpl
@@ -1,8 +1,8 @@
 {config_load file=$language_file section="edit_email"}
-<p class="caution">{#caution#}</p>
+<p class="notice caution">{#caution#}</p>
 <p class="normal">{#edit_email_exp#}</p>
 {if $errors}
-<p class="caution">{#error_headline#}</p>
+<p class="notice caution">{#error_headline#}</p>
 <ul>
 {section name=mysec loop=$errors}
 {assign var="error" value=$errors[mysec]}

--- a/themes/default/subtemplates/user_edit_pw.inc.tpl
+++ b/themes/default/subtemplates/user_edit_pw.inc.tpl
@@ -1,6 +1,6 @@
 {config_load file=$language_file section="edit_pw"}
 {if $errors}
-<p class="caution">{#error_headline#}</p>
+<p class="notice caution">{#error_headline#}</p>
 <ul>
 {section name=mysec loop=$errors}
 {assign var="error" value=$errors[mysec]}

--- a/themes/default/subtemplates/user_profile.inc.tpl
+++ b/themes/default/subtemplates/user_profile.inc.tpl
@@ -85,5 +85,5 @@
 {/if}
 
 {else}
-<p class="caution">{#user_account_doesnt_exist#}</p>
+<p class="notice caution">{#user_account_doesnt_exist#}</p>
 {/if}

--- a/themes/default/subtemplates/user_remove_account.inc.tpl
+++ b/themes/default/subtemplates/user_remove_account.inc.tpl
@@ -1,8 +1,8 @@
 {config_load file=$language_file section="remove_user_account"}
-<h1 class="caution">{#remove_user_account_h1#}</h1>
-<p>{#remove_user_account_warning#|replace:"[user_name]":$user_name}</p>
+<h1>{#remove_user_account_h1#}</h1>
+<p class="notice caution">{#remove_user_account_warning#|replace:"[user_name]":$user_name}</p>
 {if $errors}
-<p class="caution">{#error_headline#}</p>
+<p class="notice caution">{#error_headline#}</p>
 <ul>
 {section name=mysec loop=$errors}
 	{assign var="error" value=$errors[mysec]}


### PR DESCRIPTION
Until now there are three classes of system messages (`.ok`, `.caution`, `spam-note`) for paragraphs with system messages. Additionally the code contains the reuse of the class `.caution` (in example in the user settings for warning about account deleting) and the class `.spam` for marking the subject of an entry, that is classified as spam and with roughly the same rules as `.spam-note`.

With the introduction of an additional class for all the system messages, called `.notice`, we can distinct the system messages from the reuse of class `.caution`. We can handle the spam classes in the similar way by renaming the class `.spam-note` to `.spam` and by the distinction of subjects of class `.spam` from system messages by using `.notice.spam`. That way it is also possible to outsource some of the rules for `.ok`, `.caution` and `spam` (formerly `.spam-note`) to `notice`.