### PR TITLE
Change: add lazy loading attribute to img elements in forum entries

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -576,13 +576,13 @@ function do_bbcode_img($action, $attributes, $content, $params, $node_object) {
 				$strSize = $size[3];
 			}
 		}
-		if (isset($attributes['default']) && $attributes['default'] == 'left') return '<img src="'. htmlspecialchars($content) .'" class="left" alt="[image]" '. $strSize .' />';
-		if (isset($attributes['default']) && $attributes['default'] == 'right') return '<img src="'. htmlspecialchars($content) .'" class="right" alt="[image]" '. $strSize .' />';
-		if (isset($attributes['default']) && $attributes['default'] == 'thumbnail') return '<a rel="thumbnail" href="'. htmlspecialchars($content) .'"><img src="'.htmlspecialchars($content).'" class="thumbnail" alt="[image]" '. $strSize .' /></a>';
-		if (isset($attributes['default']) && $attributes['default'] == 'thumbnail-left') return '<a rel="thumbnail" href="'. htmlspecialchars($content) .'"><img src="'. htmlspecialchars($content) .'" class="thumbnail left" alt="[image]" '. $strSize .' /></a>';
-		if (isset($attributes['default']) && $attributes['default'] == 'thumbnail-right') return '<a rel="thumbnail" href="'. htmlspecialchars($content) .'"><img src="'. htmlspecialchars($content) .'" class="thumbnail right" alt="[image]" '. $strSize .' /></a>';
+		if (isset($attributes['default']) && $attributes['default'] == 'left') return '<img src="'. htmlspecialchars($content) .'" loading="lazy" class="left" alt="[image]" '. $strSize .' />';
+		if (isset($attributes['default']) && $attributes['default'] == 'right') return '<img src="'. htmlspecialchars($content) .'" loading="lazy" class="right" alt="[image]" '. $strSize .' />';
+		if (isset($attributes['default']) && $attributes['default'] == 'thumbnail') return '<a rel="thumbnail" href="'. htmlspecialchars($content) .'"><img src="'.htmlspecialchars($content).'" loading="lazy" class="thumbnail" alt="[image]" '. $strSize .' /></a>';
+		if (isset($attributes['default']) && $attributes['default'] == 'thumbnail-left') return '<a rel="thumbnail" href="'. htmlspecialchars($content) .'"><img src="'. htmlspecialchars($content) .'" loading="lazy" class="thumbnail left" alt="[image]" '. $strSize .' /></a>';
+		if (isset($attributes['default']) && $attributes['default'] == 'thumbnail-right') return '<a rel="thumbnail" href="'. htmlspecialchars($content) .'"><img src="'. htmlspecialchars($content) .'" loading="lazy" class="thumbnail right" alt="[image]" '. $strSize .' /></a>';
 		// [img]image[/img]
-		return '<img src="'. htmlspecialchars($content) .'" alt="[image]" '. $strSize .' />';
+		return '<img src="'. htmlspecialchars($content) .'" loading="lazy" alt="[image]" '. $strSize .' />';
 	}
 }
 


### PR DESCRIPTION
This adds the attribute `loading` with the value `lazy` to all images in forum entries. Images in the browser viewport will be loaded immediately and outside the viewport at the time, the browser detects that they are about to enter the viewport. Browsers, that doesn't support the attribute will ignore it and will load the images as without the attribute (so as before).



closes #666